### PR TITLE
feat(fase3): polimento visual, histórico persistente e notificações

### DIFF
--- a/backend/routes/sessoes.py
+++ b/backend/routes/sessoes.py
@@ -6,12 +6,18 @@ from selenium.common.exceptions import WebDriverException
 from backend.schemas import (
     RegistroHistorico,
     SelecaoIn,
+    SessaoHistoricaOut,
     SessaoIn,
     SessaoOut,
     ValorEncontrado,
 )
 from backend.services.session_manager import manager
-from src.db import buscar_usuario_por_id
+from src.db import (
+    buscar_usuario_por_id,
+    gravar_sessao_historica,
+    listar_alteracoes_historicas,
+    obter_sessao_historica,
+)
 from src.notifier import carregar_senha_app, enviar_email, montar_resumo_sessao
 from src.utils import validar_url
 from src.value_selector import listar_valores_com_xpath
@@ -137,20 +143,43 @@ def get_historico(session_id: str) -> list[RegistroHistorico]:
 @router.delete("/{session_id}", status_code=204)
 def delete_sessao(session_id: str) -> None:
     """
-    Encerra a sessão e dispara um e-mail com o resumo (histórico de
-    alterações) para o usuário dono da sessão. Se o e-mail falhar, a
-    sessão ainda é encerrada — o envio é best-effort.
+    Encerra a sessão:
+      1. Persiste o histórico em SQLite (para consulta posterior).
+      2. Para a thread de monitoramento e fecha o driver.
+      3. Envia e-mail de resumo para o usuário (best-effort).
     """
+    from datetime import datetime as _dt
+
     estado = manager.obter(session_id)
     if not estado:
         raise HTTPException(status_code=404, detail="Sessão não encontrada.")
 
-    # Snapshot antes do encerramento: o manager limpa o driver e os
-    # recursos, mas os dados que vamos enviar por e-mail ficam aqui.
+    # Snapshot antes do encerramento.
     url = estado.url
+    valor_inicial = estado.valor_inicial
     valor_final = estado.valor_atual
     historico = list(estado.historico)
-    usuario_row = buscar_usuario_por_id(estado.usuario_id)
+    xpath_monitorado = estado.xpath_monitorado
+    usuario_id = estado.usuario_id
+    iniciada_em = estado.iniciada_em
+    usuario_row = buscar_usuario_por_id(usuario_id)
+
+    # Persistir histórico ANTES de encerrar — se o driver.quit() levantar,
+    # pelo menos os dados já estão salvos.
+    try:
+        gravar_sessao_historica(
+            sessao_id=session_id,
+            usuario_id=usuario_id,
+            url=url,
+            xpath_monitorado=xpath_monitorado,
+            valor_inicial=valor_inicial,
+            valor_final=valor_final,
+            iniciada_em=iniciada_em.isoformat(),
+            encerrada_em=_dt.now().isoformat(),
+            alteracoes=historico,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Falha ao persistir histórico da sessão %s", session_id)
 
     ok = manager.encerrar(session_id)
     if not ok:
@@ -172,3 +201,65 @@ def delete_sessao(session_id: str) -> None:
                 )
     except Exception:  # noqa: BLE001
         logger.exception("Falha ao enviar e-mail de resumo da sessão %s", session_id)
+
+
+# ---------------------------------------------------------------------------
+# Histórico persistente
+# ---------------------------------------------------------------------------
+
+
+def _row_to_sessao_historica(row: tuple) -> SessaoHistoricaOut:
+    (
+        id_,
+        usuario_id,
+        url,
+        xpath_monitorado,
+        valor_inicial,
+        valor_final,
+        total_alteracoes,
+        iniciada_em,
+        encerrada_em,
+    ) = row
+    return SessaoHistoricaOut(
+        id=id_,
+        usuario_id=usuario_id,
+        url=url,
+        xpath_monitorado=xpath_monitorado,
+        valor_inicial=valor_inicial,
+        valor_final=valor_final,
+        total_alteracoes=total_alteracoes,
+        iniciada_em=iniciada_em,
+        encerrada_em=encerrada_em,
+    )
+
+
+@router.get(
+    "/historicas/{sessao_id}",
+    response_model=SessaoHistoricaOut,
+    tags=["historico"],
+)
+def get_sessao_historica(sessao_id: str) -> SessaoHistoricaOut:
+    """Detalhes de uma sessão encerrada no passado."""
+    row = obter_sessao_historica(sessao_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Sessão histórica não encontrada.")
+    return _row_to_sessao_historica(row)
+
+
+@router.get(
+    "/historicas/{sessao_id}/alteracoes",
+    response_model=list[RegistroHistorico],
+    tags=["historico"],
+)
+def get_alteracoes_historicas(sessao_id: str) -> list[RegistroHistorico]:
+    """Alterações registradas em uma sessão histórica."""
+    rows = listar_alteracoes_historicas(sessao_id)
+    return [
+        RegistroHistorico(
+            ciclo=ciclo,
+            timestamp=ts,
+            valor_antigo=va,
+            valor_novo=vn,
+        )
+        for ciclo, ts, va, vn in rows
+    ]

--- a/backend/routes/usuarios.py
+++ b/backend/routes/usuarios.py
@@ -2,10 +2,11 @@
 
 from fastapi import APIRouter, HTTPException
 
-from backend.schemas import UsuarioIn, UsuarioOut
+from backend.schemas import SessaoHistoricaOut, UsuarioIn, UsuarioOut
 from src.db import (
     buscar_usuario_por_id,
     cadastrar_usuario,
+    listar_sessoes_historicas,
     listar_usuarios,
 )
 from src.validators import validar_nome_usuario
@@ -39,3 +40,28 @@ def get_usuario(usuario_id: int) -> UsuarioOut:
     if not linha:
         raise HTTPException(status_code=404, detail="Usuário não encontrado.")
     return UsuarioOut(id=linha[0], nome=linha[1], email=linha[2])
+
+
+@router.get("/{usuario_id}/sessoes", response_model=list[SessaoHistoricaOut])
+def get_sessoes_usuario(usuario_id: int) -> list[SessaoHistoricaOut]:
+    """
+    Lista as sessões encerradas do usuário, mais recentes primeiro.
+    Usado pelo wizard para mostrar o "histórico" ao retornar usuário.
+    """
+    if not buscar_usuario_por_id(usuario_id):
+        raise HTTPException(status_code=404, detail="Usuário não encontrado.")
+    rows = listar_sessoes_historicas(usuario_id)
+    return [
+        SessaoHistoricaOut(
+            id=r[0],
+            usuario_id=r[1],
+            url=r[2],
+            xpath_monitorado=r[3],
+            valor_inicial=r[4],
+            valor_final=r[5],
+            total_alteracoes=r[6],
+            iniciada_em=r[7],
+            encerrada_em=r[8],
+        )
+        for r in rows
+    ]

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -65,3 +65,20 @@ class RegistroHistorico(BaseModel):
     timestamp: datetime
     valor_antigo: str
     valor_novo: str
+
+
+# ---------------------------------------------------------------------------
+# Histórico persistente de sessões encerradas
+# ---------------------------------------------------------------------------
+
+
+class SessaoHistoricaOut(BaseModel):
+    id: str
+    usuario_id: int
+    url: str
+    xpath_monitorado: Optional[str] = None
+    valor_inicial: Optional[str] = None
+    valor_final: Optional[str] = None
+    total_alteracoes: int
+    iniciada_em: datetime
+    encerrada_em: datetime

--- a/backend/services/session_manager.py
+++ b/backend/services/session_manager.py
@@ -56,6 +56,8 @@ class SessionState:
     status: str = "iniciada"
     xpath_monitorado: Optional[str] = None
     valor_atual: Optional[str] = None
+    valor_inicial: Optional[str] = None
+    iniciada_em: datetime = field(default_factory=datetime.now)
     valores_encontrados: List[dict] = field(default_factory=list)
     historico: List[RegistroAlteracao] = field(default_factory=list)
     ciclo: int = 0
@@ -134,6 +136,7 @@ class SessionManager:
 
         estado.xpath_monitorado = xpath
         estado.valor_atual = valor_inicial
+        estado.valor_inicial = valor_inicial
         estado.status = "monitorando"
 
         thread = threading.Thread(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import ErrorBoundary from './components/ErrorBoundary';
+import ToastContainer from './components/ToastContainer';
 import MonitorPage from './pages/MonitorPage';
 import SetupWizard from './pages/SetupWizard';
 
@@ -15,13 +16,14 @@ import SetupWizard from './pages/SetupWizard';
 export default function App() {
   return (
     <div className="min-h-screen">
-      <header className="bg-white border-b border-gray-200 px-6 py-3">
-        <h1 className="text-lg font-semibold text-gray-800">
+      <ToastContainer />
+      <header className="bg-white border-b border-gray-200 px-4 sm:px-6 py-3">
+        <h1 className="text-base sm:text-lg font-semibold text-gray-800">
           Monitor de Preços — <span className="text-indigo-600">MVP</span>
         </h1>
       </header>
 
-      <main className="max-w-5xl mx-auto px-6 py-8">
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
         <ErrorBoundary>
           <Routes>
             <Route path="/" element={<SetupWizard />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,23 +1,64 @@
 /**
  * Cliente HTTP centralizado para a API FastAPI.
  *
- * Fase 1 (MVP): `fetch` puro com um wrapper de erro.
- * Em fases futuras pode ganhar interceptors, retry, etc.
+ * `ApiError` carrega `status` + `detail` legível. Consumidores podem
+ * fazer `instanceof ApiError` e usar `.detail` direto no toast.
  */
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
 
+export class ApiError extends Error {
+  // Atributos declarados explicitamente (sem parameter properties) para
+  // satisfazer `erasableSyntaxOnly` do tsconfig — o build falha se o TS
+  // tiver de gerar código para inicializá-los.
+  readonly status: number;
+  readonly detail: string;
+
+  constructor(status: number, detail: string) {
+    super(detail);
+    this.name = 'ApiError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
-    ...init,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE_URL}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+      ...init,
+    });
+  } catch {
+    // Falha de rede (servidor desligado, CORS, offline...).
+    throw new ApiError(0, 'Não consegui falar com o servidor. Verifique se o backend está rodando.');
+  }
   if (!res.ok) {
-    const detail = await res.text();
-    throw new Error(`HTTP ${res.status}: ${detail}`);
+    // FastAPI devolve { detail: "..." } em erros. Tenta extrair; se
+    // não for JSON, usa o texto cru.
+    const raw = await res.text();
+    let detalhe = raw;
+    try {
+      const body = JSON.parse(raw);
+      if (typeof body?.detail === 'string') detalhe = body.detail;
+      else if (Array.isArray(body?.detail) && body.detail[0]?.msg) {
+        // Erros de validação do Pydantic vêm como array.
+        detalhe = body.detail[0].msg;
+      }
+    } catch {
+      // payload não era JSON — mantém texto.
+    }
+    throw new ApiError(res.status, detalhe || `Erro HTTP ${res.status}`);
   }
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
+}
+
+/** Extrai uma mensagem amigável de qualquer erro de chamada. */
+export function mensagemDeErro(e: unknown): string {
+  if (e instanceof ApiError) return e.detail;
+  if (e instanceof Error) return e.message;
+  return 'Erro inesperado.';
 }
 
 // --- Tipos (espelham backend/schemas.py) -----------------------------------
@@ -51,6 +92,18 @@ export interface RegistroHistorico {
   valor_novo: string;
 }
 
+export interface SessaoHistorica {
+  id: string;
+  usuario_id: number;
+  url: string;
+  xpath_monitorado: string | null;
+  valor_inicial: string | null;
+  valor_final: string | null;
+  total_alteracoes: number;
+  iniciada_em: string;
+  encerrada_em: string;
+}
+
 // --- Endpoints -------------------------------------------------------------
 
 export const api = {
@@ -80,4 +133,12 @@ export const api = {
     request<RegistroHistorico[]>(`/sessoes/${id}/historico`),
   encerrar: (id: string) =>
     request<void>(`/sessoes/${id}`, { method: 'DELETE' }),
+
+  // Histórico persistente
+  sessoesDoUsuario: (usuarioId: number) =>
+    request<SessaoHistorica[]>(`/usuarios/${usuarioId}/sessoes`),
+  sessaoHistorica: (id: string) =>
+    request<SessaoHistorica>(`/sessoes/historicas/${id}`),
+  alteracoesHistoricas: (id: string) =>
+    request<RegistroHistorico[]>(`/sessoes/historicas/${id}/alteracoes`),
 };

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,44 @@
+/**
+ * Placeholders animados para estados de carregamento.
+ *
+ * Preferimos skeletons a um texto "Carregando..." porque dão ao usuário
+ * uma ideia imediata do layout que vai aparecer — a tela não "pula"
+ * quando os dados chegam.
+ */
+
+interface SkeletonProps {
+  className?: string;
+}
+
+/** Bloco genérico com shimmer via Tailwind `animate-pulse`. */
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-gray-200 ${className}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+/** Skeleton tipificado para uma linha de lista (usuário, sessão, etc). */
+export function SkeletonRow() {
+  return (
+    <div className="border border-gray-200 rounded px-4 py-2 space-y-2">
+      <Skeleton className="h-4 w-1/3" />
+      <Skeleton className="h-3 w-2/3" />
+    </div>
+  );
+}
+
+/** Vários SkeletonRow com key automática — evita clutter no consumidor. */
+export function SkeletonList({ linhas = 3 }: { linhas?: number }) {
+  return (
+    <ul className="space-y-2">
+      {Array.from({ length: linhas }).map((_, i) => (
+        <li key={i}>
+          <SkeletonRow />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,79 @@
+/**
+ * Stack global de toasts.
+ *
+ * Montado uma única vez em App.tsx. Lê de `useToastStore` e renderiza
+ * uma pilha fixa no canto superior direito. Cada toast tem cor/ícone
+ * conforme o `tipo` e um botão "×" para dispensa manual (além do
+ * auto-dismiss disparado pelo próprio store).
+ */
+
+import { useToastStore, type ToastTipo } from '../store/toastStore';
+
+const ESTILOS: Record<ToastTipo, { bg: string; border: string; icon: string; label: string }> = {
+  sucesso: {
+    bg: 'bg-green-50',
+    border: 'border-green-300 text-green-800',
+    icon: '✓',
+    label: 'Sucesso',
+  },
+  erro: {
+    bg: 'bg-red-50',
+    border: 'border-red-300 text-red-800',
+    icon: '✕',
+    label: 'Erro',
+  },
+  info: {
+    bg: 'bg-blue-50',
+    border: 'border-blue-300 text-blue-800',
+    icon: 'ℹ',
+    label: 'Info',
+  },
+  aviso: {
+    bg: 'bg-amber-50',
+    border: 'border-amber-300 text-amber-800',
+    icon: '⚠',
+    label: 'Aviso',
+  },
+};
+
+export default function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+  const remover = useToastStore((s) => s.remover);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="fixed top-4 right-4 z-50 flex flex-col gap-2 w-[min(92vw,22rem)]"
+      role="region"
+      aria-label="Notificações"
+    >
+      {toasts.map((t) => {
+        const e = ESTILOS[t.tipo];
+        return (
+          <div
+            key={t.id}
+            role={t.tipo === 'erro' ? 'alert' : 'status'}
+            className={`${e.bg} ${e.border} border rounded-md shadow-sm px-3 py-2 flex items-start gap-2 text-sm animate-[fadeIn_0.15s_ease-out]`}
+          >
+            <span aria-hidden="true" className="font-semibold leading-5">
+              {e.icon}
+            </span>
+            <div className="flex-1 min-w-0">
+              <span className="sr-only">{e.label}: </span>
+              <p className="break-words">{t.mensagem}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => remover(t.id)}
+              className="text-current/60 hover:text-current leading-5 px-1"
+              aria-label="Dispensar notificação"
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNotificarAlteracoes.ts
+++ b/frontend/src/hooks/useNotificarAlteracoes.ts
@@ -1,0 +1,90 @@
+/**
+ * Notifica o usuário quando o store de sessão recebe uma nova alteração.
+ *
+ * Dispara em dois canais:
+ *   1. `toast.info(...)` — aparece in-app (sempre).
+ *   2. Browser Notification API — só se o usuário tiver concedido
+ *      permissão (pedida sob demanda no primeiro uso).
+ *
+ * O hook observa o comprimento do `historico` e o registro mais recente;
+ * assim evitamos notificar retroativamente os registros carregados no
+ * evento `inicial`.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useSessionStore } from '../store/sessionStore';
+import { toast } from '../store/toastStore';
+
+export function useNotificarAlteracoes(): void {
+  const historico = useSessionStore((s) => s.historico);
+  const sessao = useSessionStore((s) => s.sessao);
+
+  // Guarda o tamanho visto na última renderização. No primeiro mount, o
+  // "estado anterior" = "estado atual" → nada notifica até chegar algo
+  // novo via WebSocket.
+  const contagemAnterior = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (contagemAnterior.current === null) {
+      contagemAnterior.current = historico.length;
+      return;
+    }
+    if (historico.length <= contagemAnterior.current) {
+      contagemAnterior.current = historico.length;
+      return;
+    }
+
+    const novos = historico.slice(contagemAnterior.current);
+    contagemAnterior.current = historico.length;
+
+    for (const reg of novos) {
+      const msg = `Valor mudou: ${reg.valor_antigo} → ${reg.valor_novo}`;
+      toast.info(msg);
+      dispararNotificacaoNavegador('Monitor de preços', msg, sessao?.url);
+    }
+  }, [historico, sessao?.url]);
+}
+
+/**
+ * Envia uma Notification do navegador de forma best-effort.
+ *
+ * - Se o suporte não existir (Safari muito antigo, webview), não faz nada.
+ * - Se a permissão for `default`, pede uma vez por clique prévio. Navegadores
+ *   modernos exigem gesto do usuário — caso o pedido falhe, a função
+ *   silencia e confiamos no toast in-app.
+ */
+function dispararNotificacaoNavegador(
+  titulo: string,
+  corpo: string,
+  tag?: string,
+): void {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+
+  const permissao = Notification.permission;
+  if (permissao === 'granted') {
+    try {
+      new Notification(titulo, { body: corpo, tag });
+    } catch {
+      // alguns browsers bloqueiam Notification fora de secure contexts
+    }
+    return;
+  }
+  if (permissao === 'default') {
+    // Pede permissão silenciosamente — se negar, na próxima alteração
+    // já sai desse ramo e fica só no toast.
+    Notification.requestPermission().catch(() => {});
+  }
+}
+
+/** Solicita permissão de notificação; usado por um botão explícito. */
+export async function pedirPermissaoNotificacao(): Promise<NotificationPermission> {
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return 'denied';
+  }
+  if (Notification.permission !== 'default') return Notification.permission;
+  try {
+    return await Notification.requestPermission();
+  } catch {
+    return 'denied';
+  }
+}

--- a/frontend/src/pages/MonitorPage.tsx
+++ b/frontend/src/pages/MonitorPage.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { api } from '../api/client';
+import { api, mensagemDeErro } from '../api/client';
 import BrowserPreview from '../components/BrowserPreview';
 import { useSessionWS } from '../hooks/useSessionWS';
+import {
+  pedirPermissaoNotificacao,
+  useNotificarAlteracoes,
+} from '../hooks/useNotificarAlteracoes';
 import { useSessionStore } from '../store/sessionStore';
+import { toast } from '../store/toastStore';
 
 /**
  * Página 2 — Monitor ao vivo.
@@ -19,6 +24,8 @@ export default function MonitorPage() {
 
   // Abre/fecha a conexão WS e alimenta o store.
   useSessionWS(sessionId);
+  // Observa novas alterações e dispara toast + Notification nativa.
+  useNotificarAlteracoes();
 
   const sessao = useSessionStore((s) => s.sessao);
   const historico = useSessionStore((s) => s.historico);
@@ -28,14 +35,28 @@ export default function MonitorPage() {
 
   const [encerrando, setEncerrando] = useState(false);
   const [encerrada, setEncerrada] = useState(false);
+  const [permNotif, setPermNotif] = useState<NotificationPermission>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'denied',
+  );
+
+  // Surface WS errors as toasts. Mantemos também o texto fixo embaixo
+  // pra ficar visível mesmo depois que o toast some.
+  useEffect(() => {
+    if (conn === 'erro' && mensagem) toast.erro(mensagem);
+  }, [conn, mensagem]);
 
   async function encerrar() {
     if (encerrando) return;
     setEncerrando(true);
-    // Espera o backend confirmar: o DELETE é quem dispara o e-mail de
-    // resumo. Se der erro, ainda assim seguimos para o estado
-    // "encerrada" pra não travar a UI.
-    await api.encerrar(sessionId).catch(() => {});
+    try {
+      // Espera o backend confirmar: o DELETE é quem dispara o e-mail de
+      // resumo. Se der erro, ainda assim seguimos para o estado
+      // "encerrada" pra não travar a UI.
+      await api.encerrar(sessionId);
+      toast.sucesso('Sessão encerrada. E-mail de resumo a caminho.');
+    } catch (e) {
+      toast.aviso(mensagemDeErro(e));
+    }
     setEncerrada(true);
     // Se essa aba foi aberta como popup pelo wizard, `window.close()`
     // funciona. Caso contrário (usuário colou a URL manualmente),
@@ -46,11 +67,23 @@ export default function MonitorPage() {
     }, 1500);
   }
 
+  async function ativarNotificacoes() {
+    const resultado = await pedirPermissaoNotificacao();
+    setPermNotif(resultado);
+    if (resultado === 'granted') {
+      toast.sucesso('Notificações ativadas.');
+    } else if (resultado === 'denied') {
+      toast.aviso(
+        'Notificações bloqueadas. Você ainda verá os alertas dentro da página.',
+      );
+    }
+  }
+
   return (
     <div className="space-y-6">
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-start justify-between gap-4">
-          <div>
+      <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div className="min-w-0">
             <h2 className="text-lg font-medium">Monitoramento ativo</h2>
             <p className="text-sm text-gray-500 break-all">
               {sessao?.url ?? 'Carregando sessão...'}
@@ -59,27 +92,39 @@ export default function MonitorPage() {
               Ao encerrar, você receberá um e-mail com o resumo da sessão.
             </p>
           </div>
-          <button
-            onClick={encerrar}
-            disabled={encerrando}
-            className="px-3 py-1.5 text-sm border border-red-300 text-red-600 rounded hover:bg-red-50 disabled:opacity-60"
-          >
-            {encerrada
-              ? 'Sessão encerrada ✓'
-              : encerrando
-                ? 'Encerrando e enviando e-mail...'
-                : 'Encerrar sessão'}
-          </button>
+          <div className="flex flex-wrap gap-2">
+            {permNotif === 'default' && (
+              <button
+                onClick={ativarNotificacoes}
+                className="px-3 py-1.5 text-sm border border-indigo-300 text-indigo-700 rounded hover:bg-indigo-50"
+              >
+                Ativar notificações
+              </button>
+            )}
+            <button
+              onClick={encerrar}
+              disabled={encerrando}
+              className="px-3 py-1.5 text-sm border border-red-300 text-red-600 rounded hover:bg-red-50 disabled:opacity-60"
+            >
+              {encerrada
+                ? 'Sessão encerrada ✓'
+                : encerrando
+                  ? 'Encerrando e enviando e-mail...'
+                  : 'Encerrar sessão'}
+            </button>
+          </div>
         </div>
 
-        <dl className="grid grid-cols-4 gap-4 mt-4 text-sm">
+        <dl className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 text-sm">
           <div>
             <dt className="text-gray-500">Status</dt>
             <dd className="font-mono">{sessao?.status ?? '...'}</dd>
           </div>
           <div>
             <dt className="text-gray-500">Valor atual</dt>
-            <dd className="font-mono">{sessao?.valor_atual ?? '...'}</dd>
+            <dd className="font-mono break-all">
+              {sessao?.valor_atual ?? '...'}
+            </dd>
           </div>
           <div>
             <dt className="text-gray-500">Ciclo</dt>
@@ -92,7 +137,7 @@ export default function MonitorPage() {
         </dl>
       </section>
 
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
         <h3 className="font-medium mb-2">Navegador (preview)</h3>
         <BrowserPreview />
         <p className="text-xs text-gray-400 mt-2">
@@ -100,42 +145,44 @@ export default function MonitorPage() {
         </p>
       </section>
 
-      <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
         <h3 className="font-medium mb-3">Histórico de alterações</h3>
         {historico.length === 0 ? (
           <p className="text-sm text-gray-500">
             Nenhuma alteração ainda. O monitor compara o valor a cada 15s.
           </p>
         ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-gray-500 border-b">
-                <th className="py-2">Ciclo</th>
-                <th>Horário</th>
-                <th>De</th>
-                <th>Para</th>
-              </tr>
-            </thead>
-            <tbody>
-              {historico.map((r) => (
-                <tr key={r.ciclo} className="border-b last:border-b-0">
-                  <td className="py-2 font-mono">{r.ciclo}</td>
-                  <td className="font-mono">
-                    {new Date(r.timestamp).toLocaleTimeString('pt-BR')}
-                  </td>
-                  <td className="font-mono">{r.valor_antigo}</td>
-                  <td className="font-mono text-indigo-700">{r.valor_novo}</td>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[480px]">
+              <thead>
+                <tr className="text-left text-gray-500 border-b">
+                  <th className="py-2">Ciclo</th>
+                  <th>Horário</th>
+                  <th>De</th>
+                  <th>Para</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {historico.map((r) => (
+                  <tr key={r.ciclo} className="border-b last:border-b-0">
+                    <td className="py-2 font-mono">{r.ciclo}</td>
+                    <td className="font-mono">
+                      {new Date(r.timestamp).toLocaleTimeString('pt-BR')}
+                    </td>
+                    <td className="font-mono">{r.valor_antigo}</td>
+                    <td className="font-mono text-indigo-700">
+                      {r.valor_novo}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
 
       {(conn === 'erro' || conn === 'desconectado') && mensagem && (
-        <p className="text-red-600 text-sm">
-          {mensagem}
-        </p>
+        <p className="text-red-600 text-sm">{mensagem}</p>
       )}
     </div>
   );

--- a/frontend/src/pages/SetupWizard.tsx
+++ b/frontend/src/pages/SetupWizard.tsx
@@ -13,10 +13,27 @@
 import { useEffect, useState } from 'react';
 import {
   api,
+  mensagemDeErro,
   type Sessao,
+  type SessaoHistorica,
   type Usuario,
   type ValorEncontrado,
 } from '../api/client';
+import { toast } from '../store/toastStore';
+import { Skeleton, SkeletonList } from '../components/Skeleton';
+
+/** Chave do localStorage que lembra a última URL informada. */
+const LS_ULTIMA_URL = 'monitor.ultimaUrl';
+
+/** Valida forma básica de URL http(s). Reutilizado pelo input inline. */
+function urlValida(v: string): boolean {
+  try {
+    const u = new URL(v.trim());
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
 
 type Step = 'usuario' | 'url' | 'valor';
 
@@ -116,29 +133,31 @@ function Steps({ atual }: { atual: Step }) {
 function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [carregando, setCarregando] = useState(true);
-  const [erro, setErro] = useState<string | null>(null);
 
   const [nome, setNome] = useState('');
   const [email, setEmail] = useState('');
   const [criando, setCriando] = useState(false);
 
+  const nomeOk = nome.trim().length >= 3;
+  const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+
   useEffect(() => {
     api
       .listarUsuarios()
       .then(setUsuarios)
-      .catch((e) => setErro(String(e)))
+      .catch((e) => toast.erro(mensagemDeErro(e)))
       .finally(() => setCarregando(false));
   }, []);
 
   async function cadastrar(e: React.FormEvent) {
     e.preventDefault();
-    setErro(null);
     setCriando(true);
     try {
       const novo = await api.criarUsuario(nome.trim(), email.trim());
+      toast.sucesso(`Bem-vindo, ${novo.nome}!`);
       onPronto(novo);
     } catch (e) {
-      setErro(String(e));
+      toast.erro(mensagemDeErro(e));
     } finally {
       setCriando(false);
     }
@@ -148,7 +167,7 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
     <div className="grid gap-6 md:grid-cols-2">
       <section className="bg-white rounded-lg border border-gray-200 p-6">
         <h2 className="text-lg font-medium mb-4">Usuários cadastrados</h2>
-        {carregando && <p className="text-gray-500">Carregando...</p>}
+        {carregando && <SkeletonList linhas={3} />}
         {!carregando && usuarios.length === 0 && (
           <p className="text-gray-500">
             Nenhum usuário ainda. Cadastre ao lado.
@@ -181,6 +200,11 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
               minLength={3}
               className="mt-1 w-full px-3 py-2 border border-gray-300 rounded"
             />
+            {nome.length > 0 && !nomeOk && (
+              <span className="text-xs text-red-600">
+                Mínimo 3 caracteres.
+              </span>
+            )}
           </label>
           <label className="block">
             <span className="text-sm text-gray-700">E-mail</span>
@@ -191,16 +215,18 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
               required
               className="mt-1 w-full px-3 py-2 border border-gray-300 rounded"
             />
+            {email.length > 0 && !emailOk && (
+              <span className="text-xs text-red-600">E-mail inválido.</span>
+            )}
           </label>
           <button
             type="submit"
-            disabled={criando}
+            disabled={criando || !nomeOk || !emailOk}
             className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-60"
           >
             {criando ? 'Criando...' : 'Cadastrar e continuar'}
           </button>
         </form>
-        {erro && <p className="text-red-600 text-sm mt-3">{erro}</p>}
       </section>
     </div>
   );
@@ -219,20 +245,43 @@ function StepUrl({
   onPronto: (s: Sessao) => void;
   onVoltar: () => void;
 }) {
-  const [url, setUrl] = useState('');
+  // Recupera a última URL usada por este navegador. É apenas um
+  // valor inicial — o usuário pode apagar livremente.
+  const [url, setUrl] = useState(
+    () => localStorage.getItem(LS_ULTIMA_URL) ?? '',
+  );
   const [headless, setHeadless] = useState(true);
   const [iniciando, setIniciando] = useState(false);
-  const [erro, setErro] = useState<string | null>(null);
+
+  const [historico, setHistorico] = useState<SessaoHistorica[]>([]);
+  const [carregandoHist, setCarregandoHist] = useState(true);
+
+  const urlOk = urlValida(url);
+
+  useEffect(() => {
+    // Histórico persistente do usuário — permite reusar uma URL antiga
+    // num clique. Falha silenciosa: não é crítico.
+    api
+      .sessoesDoUsuario(usuario.id)
+      .then(setHistorico)
+      .catch(() => {})
+      .finally(() => setCarregandoHist(false));
+  }, [usuario.id]);
 
   async function iniciar(e: React.FormEvent) {
     e.preventDefault();
-    setErro(null);
+    if (!urlOk) {
+      toast.aviso('Informe uma URL http(s) válida.');
+      return;
+    }
     setIniciando(true);
     try {
-      const sessao = await api.criarSessao(usuario.id, url.trim(), headless);
+      const urlLimpa = url.trim();
+      const sessao = await api.criarSessao(usuario.id, urlLimpa, headless);
+      localStorage.setItem(LS_ULTIMA_URL, urlLimpa);
       onPronto(sessao);
     } catch (e) {
-      setErro(String(e));
+      toast.erro(mensagemDeErro(e));
     } finally {
       setIniciando(false);
     }
@@ -254,8 +303,17 @@ function StepUrl({
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://site.com/produto"
             required
-            className="mt-1 w-full px-3 py-2 border border-gray-300 rounded"
+            className={`mt-1 w-full px-3 py-2 border rounded ${
+              url.length > 0 && !urlOk
+                ? 'border-red-400'
+                : 'border-gray-300'
+            }`}
           />
+          {url.length > 0 && !urlOk && (
+            <span className="text-xs text-red-600">
+              Use http:// ou https://
+            </span>
+          )}
         </label>
 
         <fieldset>
@@ -298,7 +356,7 @@ function StepUrl({
           </button>
           <button
             type="submit"
-            disabled={iniciando}
+            disabled={iniciando || !urlOk}
             className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-60"
           >
             {iniciando ? 'Abrindo navegador...' : 'Continuar'}
@@ -306,8 +364,67 @@ function StepUrl({
         </div>
       </form>
 
-      {erro && <p className="text-red-600 text-sm mt-3">{erro}</p>}
+      <SessoesAnteriores
+        carregando={carregandoHist}
+        historico={historico}
+        onReusar={(u) => setUrl(u)}
+      />
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Widget — sessões anteriores do usuário
+// ---------------------------------------------------------------------------
+
+function SessoesAnteriores({
+  carregando,
+  historico,
+  onReusar,
+}: {
+  carregando: boolean;
+  historico: SessaoHistorica[];
+  onReusar: (url: string) => void;
+}) {
+  const [aberto, setAberto] = useState(false);
+
+  if (carregando) return null;
+  if (historico.length === 0) return null;
+
+  return (
+    <details
+      open={aberto}
+      onToggle={(e) => setAberto((e.target as HTMLDetailsElement).open)}
+      className="mt-6 border-t border-gray-200 pt-4"
+    >
+      <summary className="cursor-pointer text-sm text-indigo-600 hover:text-indigo-700 select-none">
+        {aberto ? '▾' : '▸'} Sessões anteriores ({historico.length})
+      </summary>
+      <ul className="mt-3 space-y-2">
+        {historico.slice(0, 10).map((s) => (
+          <li
+            key={s.id}
+            className="text-sm border border-gray-200 rounded p-2 flex items-center justify-between gap-2"
+          >
+            <div className="min-w-0">
+              <p className="truncate font-mono text-xs">{s.url}</p>
+              <p className="text-xs text-gray-500">
+                {new Date(s.encerrada_em).toLocaleString('pt-BR')} •{' '}
+                {s.total_alteracoes} alterações • final:{' '}
+                <span className="font-mono">{s.valor_final ?? '—'}</span>
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onReusar(s.url)}
+              className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-indigo-50"
+            >
+              Reusar URL
+            </button>
+          </li>
+        ))}
+      </ul>
+    </details>
   );
 }
 
@@ -328,7 +445,6 @@ function StepValor({
   const [preview, setPreview] = useState<string | null>(null);
   const [carregando, setCarregando] = useState(true);
   const [selecionando, setSelecionando] = useState<number | null>(null);
-  const [erro, setErro] = useState<string | null>(null);
 
   useEffect(() => {
     // Busca valores + screenshot em paralelo. O screenshot é apenas
@@ -344,7 +460,7 @@ function StepValor({
       if (resValores.status === 'fulfilled') {
         setValores(resValores.value);
       } else {
-        setErro(String(resValores.reason));
+        toast.erro(mensagemDeErro(resValores.reason));
       }
       if (resScreenshot.status === 'fulfilled') {
         setPreview(resScreenshot.value.data);
@@ -357,13 +473,13 @@ function StepValor({
   }, [sessao.id]);
 
   async function selecionar(v: ValorEncontrado) {
-    setErro(null);
     setSelecionando(v.indice);
     try {
       await api.selecionarValor(sessao.id, v.xpath, v.text);
+      toast.sucesso('Monitoramento iniciado! Abrindo painel ao vivo...');
       onPronto();
     } catch (e) {
-      setErro(String(e));
+      toast.erro(mensagemDeErro(e));
       setSelecionando(null);
     }
   }
@@ -393,17 +509,22 @@ function StepValor({
             alt="Prévia do site monitorado"
             className="w-full h-full object-contain"
           />
+        ) : carregando ? (
+          <Skeleton className="w-full h-full !rounded-none" />
         ) : (
           <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
-            {carregando ? 'Capturando prévia do site...' : 'Sem prévia.'}
+            Sem prévia.
           </div>
         )}
       </div>
 
       {carregando && (
-        <p className="text-gray-500">Extraindo valores da página...</p>
+        <div className="grid gap-2 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-12" />
+          ))}
+        </div>
       )}
-      {erro && <p className="text-red-600 text-sm mb-3">{erro}</p>}
 
       {!carregando && valores.length === 0 && (
         <p className="text-gray-500">Nenhum valor numérico encontrado.</p>

--- a/frontend/src/store/toastStore.ts
+++ b/frontend/src/store/toastStore.ts
@@ -1,0 +1,42 @@
+/**
+ * Store de toasts (notificações efêmeras).
+ *
+ * Qualquer componente pode disparar `toast.sucesso("...")` e o
+ * `<ToastContainer />` montado em App.tsx renderiza automaticamente.
+ * Os toasts somem sozinhos após `duracao` ms (default 3.5s).
+ */
+
+import { create } from 'zustand';
+
+export type ToastTipo = 'sucesso' | 'erro' | 'info' | 'aviso';
+
+export interface Toast {
+  id: string;
+  tipo: ToastTipo;
+  mensagem: string;
+}
+
+interface ToastStore {
+  toasts: Toast[];
+  emitir: (tipo: ToastTipo, mensagem: string, duracao?: number) => void;
+  remover: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set, get) => ({
+  toasts: [],
+  emitir: (tipo, mensagem, duracao = 3500) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    set((st) => ({ toasts: [...st.toasts, { id, tipo, mensagem }] }));
+    window.setTimeout(() => get().remover(id), duracao);
+  },
+  remover: (id) =>
+    set((st) => ({ toasts: st.toasts.filter((t) => t.id !== id) })),
+}));
+
+/** API ergonômica para uso fora de componentes React. */
+export const toast = {
+  sucesso: (m: string) => useToastStore.getState().emitir('sucesso', m),
+  erro: (m: string) => useToastStore.getState().emitir('erro', m, 5000),
+  info: (m: string) => useToastStore.getState().emitir('info', m),
+  aviso: (m: string) => useToastStore.getState().emitir('aviso', m, 4500),
+};

--- a/src/db.py
+++ b/src/db.py
@@ -11,7 +11,7 @@ DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "dados.
 
 
 def inicializar_banco() -> None:
-    """Cria a tabela de usuários caso não exista. O(1)"""
+    """Cria as tabelas do app caso não existam. O(1)"""
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             """
@@ -21,6 +21,45 @@ def inicializar_banco() -> None:
                 email TEXT NOT NULL
             )
             """
+        )
+        # Histórico de sessões encerradas. Populada pelo DELETE
+        # /sessoes/{id}. Guarda o resumo da sessão para o usuário
+        # consultar depois, mesmo com o backend reiniciado.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessoes_historicas (
+                id                TEXT PRIMARY KEY,
+                usuario_id        INTEGER NOT NULL,
+                url               TEXT NOT NULL,
+                xpath_monitorado  TEXT,
+                valor_inicial     TEXT,
+                valor_final       TEXT,
+                total_alteracoes  INTEGER NOT NULL DEFAULT 0,
+                iniciada_em       TEXT NOT NULL,
+                encerrada_em      TEXT NOT NULL,
+                FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+            )
+            """
+        )
+        # Alterações detectadas durante uma sessão histórica. Chaveada
+        # pelo id da sessão (não pelo próprio ciclo) para suportar
+        # múltiplas sessões com mesmo ciclo.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS alteracoes_historicas (
+                sessao_id     TEXT NOT NULL,
+                ciclo         INTEGER NOT NULL,
+                timestamp     TEXT NOT NULL,
+                valor_antigo  TEXT NOT NULL,
+                valor_novo    TEXT NOT NULL,
+                PRIMARY KEY (sessao_id, ciclo),
+                FOREIGN KEY (sessao_id) REFERENCES sessoes_historicas(id)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessoes_historicas_usuario "
+            "ON sessoes_historicas(usuario_id, encerrada_em DESC)"
         )
         conn.commit()
 
@@ -56,3 +95,120 @@ def buscar_usuario_por_id(usuario_id: int) -> tuple[int, str, str] | None:
             (usuario_id,),
         ).fetchone()
         return row
+
+
+# ---------------------------------------------------------------------------
+# Histórico de sessões
+# ---------------------------------------------------------------------------
+
+
+def gravar_sessao_historica(
+    sessao_id: str,
+    usuario_id: int,
+    url: str,
+    xpath_monitorado: str | None,
+    valor_inicial: str | None,
+    valor_final: str | None,
+    iniciada_em: str,
+    encerrada_em: str,
+    alteracoes: list,
+) -> None:
+    """
+    Persiste uma sessão encerrada + suas alterações em uma única
+    transação. `alteracoes` é uma lista de objetos com `.ciclo`,
+    `.timestamp` (datetime), `.valor_antigo`, `.valor_novo`.
+
+    Complexidade: O(k) onde k é o número de alterações.
+    """
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO sessoes_historicas (
+                id, usuario_id, url, xpath_monitorado,
+                valor_inicial, valor_final, total_alteracoes,
+                iniciada_em, encerrada_em
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sessao_id,
+                usuario_id,
+                url,
+                xpath_monitorado,
+                valor_inicial,
+                valor_final,
+                len(alteracoes),
+                iniciada_em,
+                encerrada_em,
+            ),
+        )
+        # Limpa alterações antigas dessa sessão (caso de re-gravação)
+        conn.execute(
+            "DELETE FROM alteracoes_historicas WHERE sessao_id = ?",
+            (sessao_id,),
+        )
+        conn.executemany(
+            """
+            INSERT INTO alteracoes_historicas (
+                sessao_id, ciclo, timestamp, valor_antigo, valor_novo
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    sessao_id,
+                    r.ciclo,
+                    r.timestamp.isoformat(),
+                    r.valor_antigo,
+                    r.valor_novo,
+                )
+                for r in alteracoes
+            ],
+        )
+        conn.commit()
+
+
+def listar_sessoes_historicas(usuario_id: int) -> list[tuple]:
+    """
+    Retorna as sessões encerradas de um usuário, mais recentes primeiro.
+
+    Complexidade: O(k log n) — lookup indexado por usuario_id, ordenação
+    já usa o índice composto (usuario_id, encerrada_em DESC).
+    """
+    with sqlite3.connect(DB_PATH) as conn:
+        return conn.execute(
+            """
+            SELECT id, usuario_id, url, xpath_monitorado, valor_inicial,
+                   valor_final, total_alteracoes, iniciada_em, encerrada_em
+            FROM sessoes_historicas
+            WHERE usuario_id = ?
+            ORDER BY encerrada_em DESC
+            """,
+            (usuario_id,),
+        ).fetchall()
+
+
+def obter_sessao_historica(sessao_id: str) -> tuple | None:
+    """Busca uma sessão histórica pelo id. O(log n)."""
+    with sqlite3.connect(DB_PATH) as conn:
+        return conn.execute(
+            """
+            SELECT id, usuario_id, url, xpath_monitorado, valor_inicial,
+                   valor_final, total_alteracoes, iniciada_em, encerrada_em
+            FROM sessoes_historicas
+            WHERE id = ?
+            """,
+            (sessao_id,),
+        ).fetchone()
+
+
+def listar_alteracoes_historicas(sessao_id: str) -> list[tuple]:
+    """Retorna as alterações de uma sessão histórica, em ordem cronológica."""
+    with sqlite3.connect(DB_PATH) as conn:
+        return conn.execute(
+            """
+            SELECT ciclo, timestamp, valor_antigo, valor_novo
+            FROM alteracoes_historicas
+            WHERE sessao_id = ?
+            ORDER BY ciclo ASC
+            """,
+            (sessao_id,),
+        ).fetchall()

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -14,24 +14,62 @@ from src.constants import SMTP_HOST, SMTP_PORT
 logger = logging.getLogger(__name__)
 
 
-def carregar_senha_app() -> str:
-    """Carrega a senha de app do Gmail a partir do arquivo .env. O(1)"""
-    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env")
-    if os.path.exists(env_path):
-        with open(env_path) as f:
-            for linha in f:
-                if linha.startswith("GMAIL_APP_PASSWORD="):
-                    return linha.split("=", 1)[1].strip()
+def _ler_env(chave: str) -> str:
+    """Leitor simples de chave=valor em `.env` (O(n) nas linhas do arquivo)."""
+    env_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", ".env"
+    )
+    if not os.path.exists(env_path):
+        return ""
+    prefixo = f"{chave}="
+    with open(env_path) as f:
+        for linha in f:
+            if linha.startswith(prefixo):
+                return linha.split("=", 1)[1].strip()
     return ""
 
 
-def enviar_email(destinatario: str, senha_app: str, assunto: str, corpo: str) -> bool:
+def carregar_senha_app() -> str:
+    """Carrega `GMAIL_APP_PASSWORD` do `.env`. O(1) amortizado."""
+    return _ler_env("GMAIL_APP_PASSWORD")
+
+
+def carregar_remetente() -> str:
+    """
+    Email da conta que autentica no SMTP.
+
+    Tenta `GMAIL_USER`; se não existir, tenta `GMAIL_FROM`. Vazio
+    se não estiver configurado — nesse caso o caller deve decidir
+    se pula o envio.
+    """
+    return _ler_env("GMAIL_USER") or _ler_env("GMAIL_FROM")
+
+
+def enviar_email(
+    destinatario: str,
+    senha_app: str,
+    assunto: str,
+    corpo: str,
+    remetente: Optional[str] = None,
+) -> bool:
     """
     Envia um e-mail via Gmail SMTP.
-    O remetente é o próprio destinatário (usa a conta do usuário). O(1)
+
+    A autenticação é feita com `remetente` + `senha_app` — essa é a
+    conta dona da senha de app do `.env`. O e-mail sai **do** remetente
+    e é entregue **ao** `destinatario`, que pode ser qualquer endereço.
+
+    Se `remetente` não for passado, cai pro `GMAIL_USER` do `.env`; se
+    mesmo assim estiver vazio, usa o próprio destinatário (comportamento
+    antigo, que só funciona quando o destinatário é o dono da senha).
+
+    O(1).
     """
+    if not remetente:
+        remetente = carregar_remetente() or destinatario
+
     msg = MIMEMultipart()
-    msg["From"] = destinatario
+    msg["From"] = remetente
     msg["To"] = destinatario
     msg["Subject"] = assunto
     msg.attach(MIMEText(corpo, "plain", "utf-8"))
@@ -39,12 +77,18 @@ def enviar_email(destinatario: str, senha_app: str, assunto: str, corpo: str) ->
     try:
         with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as servidor:
             servidor.starttls()
-            servidor.login(destinatario, senha_app)
+            servidor.login(remetente, senha_app)
             servidor.send_message(msg)
-        logger.info("LOG | E-mail enviado para %s", destinatario)
+        logger.info(
+            "LOG | E-mail enviado de %s para %s", remetente, destinatario
+        )
         return True
     except smtplib.SMTPAuthenticationError:
-        logger.error("Falha de autenticação SMTP. Verifique a senha de app do Gmail.")
+        logger.error(
+            "Falha de autenticação SMTP para %s. "
+            "Verifique GMAIL_USER e GMAIL_APP_PASSWORD no .env.",
+            remetente,
+        )
         return False
     except smtplib.SMTPException as exc:
         logger.error("Erro ao enviar e-mail: %s", exc)


### PR DESCRIPTION
## Summary
- **Histórico persistente**: sessões encerradas viram linhas em `sessoes_historicas` + `alteracoes_historicas` (SQLite). DELETE `/sessoes/{id}` agora grava o snapshot **antes** de encerrar o driver, então um crash no `driver.quit()` não perde dados.
- **Novos endpoints REST**: `GET /usuarios/{id}/sessoes`, `GET /sessoes/historicas/{id}`, `GET /sessoes/historicas/{id}/alteracoes` — consumidos pelo wizard para mostrar "sessões anteriores" do usuário com botão _Reusar URL_.
- **UX de erro amigável**: cliente HTTP ganha `ApiError` + `mensagemDeErro()` que extrai o `detail` do FastAPI (incluindo array de validação do Pydantic) e trata falhas de rede (status 0) com texto legível.
- **Sistema de toast**: store Zustand + `<ToastContainer />` global (sucesso/erro/info/aviso, auto-dismiss, dispensa manual). Todos os `setErro(String(e))` do wizard/monitor viraram `toast.erro(mensagemDeErro(e))`.
- **Validação inline**: nome, e-mail e URL validados em tempo real com feedback abaixo do input; botão "Continuar" fica desabilitado até o form ser válido.
- **Preferências**: `localStorage` guarda a última URL usada e pré-preenche o próximo wizard. Formulários já avançam com Enter por default (submit nativo).
- **Notificações do navegador**: hook `useNotificarAlteracoes` dispara `toast.info` + `Notification` nativa a cada novo registro no histórico; botão _Ativar notificações_ aparece enquanto a permissão está em `default`.
- **Polimento visual**: componente `<Skeleton />` substitui os "Carregando..." no wizard, header/main ganharam paddings responsivos, grid do MonitorPage colapsa em 2 colunas no mobile, tabela do histórico vira scroll horizontal.
- **Fix SMTP** (commit `f1cacc4`): remetente separado do destinatário (variável `GMAIL_USER`), corrigindo envio cross-account.

Closes #29.

## Test plan
- [x] Backend: subir `uvicorn backend.main:app --reload`, cadastrar usuário, criar sessão, selecionar valor, encerrar → linha em `sessoes_historicas` aparece, `GET /usuarios/{id}/sessoes` lista a sessão e `GET /sessoes/historicas/{id}/alteracoes` devolve o histórico.
- [x] Frontend: `npm run dev`, passar pelas 3 etapas do wizard → toasts aparecem em cada ação, URL errada mostra erro inline, Enter avança formulários.
- [x] Recarregar a página de setup → URL anterior pré-preenchida; a seção "Sessões anteriores" lista as sessões encerradas com botão de reusar.
- [x] MonitorPage: clicar "Ativar notificações" → browser pede permissão; quando o valor muda, aparecem toast + notification nativa (permissão concedida).
- [x] Encerrar sessão → toast de sucesso, e-mail de resumo chega no inbox do usuário logado.
- [x] Abrir DevTools no mobile (375px) → tudo cabe, tabela rola horizontalmente, botões quebram em linhas sem vazar.