### PR TITLE
feat(fase4): validação strict, testes, Docker e análise Big O

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Reduz contexto enviado ao daemon Docker — builds mais rápidos.
+.git
+.gitignore
+.venv
+__pycache__
+*.pyc
+node_modules
+frontend/node_modules
+frontend/dist
+dist
+dados.db
+*.log
+.vscode
+.idea
+.DS_Store

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# Imagem do backend FastAPI + Selenium.
+#
+# Base: python:3.12-slim + Chromium + ChromeDriver. Evitamos
+# chromedriver via webdriver-manager (que baixa em runtime) porque
+# dentro de um container queremos imagem auto-contida.
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Dependências de sistema para Chromium headless. Os pacotes `chromium`
+# e `chromium-driver` do debian-slim casam na versão, então o Selenium
+# não reclama de mismatch.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       chromium \
+       chromium-driver \
+       fonts-liberation \
+       libnss3 \
+       libxss1 \
+       libasound2 \
+       ca-certificates \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# O Selenium 4 lê o binário do Chrome via PATH quando usamos Service()
+# sem argumentos — já é o default aqui.
+ENV CHROME_BIN=/usr/bin/chromium \
+    CHROMEDRIVER_BIN=/usr/bin/chromedriver
+
+WORKDIR /app
+
+# Instala dependências em camada separada pra aproveitar o cache.
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+# Copia só o necessário pra rodar a API.
+COPY backend/ ./backend/
+COPY src/ ./src/
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+#
+# Build multi-stage do frontend:
+#   1. `builder`: roda `npm ci && npm run build` gerando `dist/`.
+#   2. `runner`: serve `dist/` com nginx — leve, zero Node em produção.
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Camadas de cache: lockfile antes do código-fonte.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+
+# VITE_API_BASE_URL vira variável de build (não runtime) porque o Vite
+# inlineia o valor no bundle. Para trocar em deploy, reconstrua a imagem
+# ou use um placeholder + replace no entrypoint.
+ARG VITE_API_BASE_URL=http://localhost:8000
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runner
+COPY --from=builder /app/dist /usr/share/nginx/html
+# Config mínimo: SPA fallback para rotas do React Router.
+RUN printf 'server {\n\
+    listen 80;\n\
+    root /usr/share/nginx/html;\n\
+    location / { try_files $uri /index.html; }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/README_frontend.md
+++ b/README_frontend.md
@@ -1,0 +1,101 @@
+# Frontend — Monitor de Preços
+
+SPA em React + TypeScript que consome a API FastAPI do backend.
+
+## Stack
+
+| Camada             | Tecnologia                              |
+| ------------------ | --------------------------------------- |
+| Build / dev-server | [Vite](https://vitejs.dev)              |
+| UI                 | React 19 + TypeScript                   |
+| Styling            | Tailwind CSS 3                          |
+| Estado global      | [Zustand](https://github.com/pmndrs/zustand) |
+| Validação          | [Zod](https://zod.dev)                  |
+| HTTP               | `fetch` nativo + cliente fino (`api/client.ts`) |
+| Streaming ao vivo  | WebSocket (`hooks/useSessionWS`)        |
+| Testes             | Vitest + Testing Library + jsdom        |
+
+## Estrutura
+
+```
+frontend/src/
+├── api/
+│   ├── client.ts        # fetch + ApiError + retry em verbos idempotentes
+│   └── schemas.ts       # Zod schemas (espelham Pydantic do backend)
+├── components/
+│   ├── BrowserPreview.tsx  # stream de screenshots do monitor
+│   ├── ErrorBoundary.tsx   # captura erros de render
+│   ├── Skeleton.tsx        # placeholders de loading
+│   └── ToastContainer.tsx  # stack global de notificações
+├── hooks/
+│   ├── useSessionWS.ts            # conexão + reconnect do WS
+│   └── useNotificarAlteracoes.ts  # toast + Notification nativa
+├── pages/
+│   ├── SetupWizard.tsx  # fluxo de 3 passos até escolher o valor
+│   └── MonitorPage.tsx  # painel ao vivo (chega via /monitor/:id)
+├── store/
+│   ├── sessionStore.ts  # estado da sessão ativa (WS)
+│   └── toastStore.ts    # fila de toasts + API `toast.sucesso/erro/...`
+└── test/                # suites Vitest
+```
+
+## Scripts
+
+```bash
+npm install          # dependências
+npm run dev          # dev-server em http://localhost:5173
+npm run build        # typecheck + bundle para dist/
+npm run test         # vitest run (CI)
+npm run test:watch   # vitest em modo interativo
+npm run lint         # eslint
+npm run preview      # serve o dist/ localmente
+```
+
+## Variáveis de ambiente
+
+| Variável             | Default                 | Descrição                               |
+| -------------------- | ----------------------- | --------------------------------------- |
+| `VITE_API_BASE_URL`  | `http://localhost:8000` | Base das chamadas HTTP/WS               |
+
+O Vite inlineia o valor no bundle — troca requer rebuild.
+
+## Fluxo
+
+1. **Step Usuário** — lista existentes ou cadastra novo (validação Zod
+   em tempo real; strict no backend barra campos desconhecidos).
+2. **Step URL** — valida `http(s)://`, lembra a última URL via
+   `localStorage`, mostra sessões anteriores do usuário.
+3. **Step Valor** — screenshot via CDP + lista de números encontrados.
+   Escolher um abre o `/monitor/:id` em nova guia.
+4. **MonitorPage** — WebSocket recebe `inicial`, `ciclo`, `alteracao`,
+   `screenshot`, `encerrada`. Cada `alteracao` dispara toast +
+   `Notification` nativa (quando concedida).
+
+## Tratamento de erros
+
+- `ApiError` (em `api/client.ts`) carrega `status` + `detail`.
+- `mensagemDeErro(e)` extrai texto legível: array de validação do
+  Pydantic → `body.detail[0].msg`; falha de rede → status 0 com
+  mensagem genérica.
+- Falhas de rede em GET/HEAD/OPTIONS passam por 2 retries com backoff
+  (250ms, 750ms). POST/DELETE não são refeitos automaticamente.
+- `<ToastContainer />` em App.tsx renderiza a fila global; qualquer
+  módulo usa `toast.sucesso(...)` / `toast.erro(...)`.
+- `<ErrorBoundary />` envolve as rotas — erros de render caem na UI
+  de fallback em vez de quebrar a tela inteira.
+
+## Produção via Docker
+
+Do root do repo:
+
+```bash
+docker compose up --build
+```
+
+Sobe backend em `:8000` e frontend (nginx) em `:5173`. Veja o
+`docker-compose.yml` pra variáveis (`GMAIL_USER`, `CORS_ORIGINS`).
+
+## Análise de complexidade
+
+Consulte [`docs/complexidade_frontend.md`](docs/complexidade_frontend.md)
+para a análise Big O dos principais fluxos do frontend.

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,33 +10,67 @@ Sobe em `localhost:8000` e expõe os recursos:
 
 Para rodar em desenvolvimento:
     uvicorn backend.main:app --reload --port 8000
+
+### Configuração via ambiente (Fase 4)
+
+- `CORS_ORIGINS`: lista separada por vírgulas de origens permitidas.
+  Default contempla o Vite dev server em `localhost` e `127.0.0.1`.
+  Em produção, defina com o domínio público do frontend.
 """
+
+import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.middlewares.rate_limit import RateLimitMiddleware
 from backend.routes import sessoes, usuarios, websocket
 from src.db import inicializar_banco
 
+
+def _carregar_origens_cors() -> list[str]:
+    """
+    Lê `CORS_ORIGINS` do ambiente (separado por vírgulas). Se ausente,
+    devolve apenas as origens de dev — seguro por default.
+    """
+    bruto = os.environ.get("CORS_ORIGINS")
+    if not bruto:
+        return ["http://localhost:5173", "http://127.0.0.1:5173"]
+    return [x.strip() for x in bruto.split(",") if x.strip()]
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    # `on_event` foi deprecado; lifespan async é o padrão atual.
+    inicializar_banco()
+    yield
+
+
 app = FastAPI(
     title="Monitor de Preços API",
-    version="0.1.0",
-    description="Backend HTTP do assistente de lances (Fase 1 — MVP).",
+    version="1.0.0",
+    description="Backend HTTP do assistente de lances.",
+    lifespan=lifespan,
 )
 
-# CORS liberado para o Vite dev server. Em prod (Fase 4) restringir.
+# CORS restrito: apenas origens conhecidas, métodos usados pela SPA e
+# cabeçalhos estritamente necessários. `allow_credentials=False` porque
+# não usamos cookies/sessão — só precisaria habilitar se migrássemos
+# para auth com cookie.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_carregar_origens_cors(),
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+    max_age=600,
 )
 
-
-@app.on_event("startup")
-def startup() -> None:
-    inicializar_banco()
+# Rate limiting — protege endpoints críticos contra loops acidentais
+# do frontend e ataques de força bruta em cadastro/criação de sessão.
+# Aplicado via middleware; rotas não-listadas passam sem contagem.
+app.add_middleware(RateLimitMiddleware)
 
 
 @app.get("/health", tags=["infra"])

--- a/backend/middlewares/rate_limit.py
+++ b/backend/middlewares/rate_limit.py
@@ -1,0 +1,111 @@
+"""
+Rate limiting in-memory com token bucket simplificado.
+
+Por que um middleware caseiro em vez de `slowapi`:
+    - zero dep nova
+    - só protegemos 3 endpoints — não justifica trazer Redis + lib
+    - os limites são leves o suficiente para caber num dicionário
+
+Escopo:
+    - Chave = (IP do cliente, rota protegida).
+    - Cada chave tem uma janela deslizante (fifo de timestamps).
+    - Quando o número de chamadas dentro da janela >= limite, devolve
+      HTTP 429 com `Retry-After` em segundos.
+
+Limitações (documentadas):
+    - Memória local: se subir em mais de 1 processo, cada worker tem seu
+      próprio contador. Para o escopo deste projeto (entrega acadêmica,
+      1 processo) é aceitável.
+    - Não persiste entre reinícios — intencional, é rate limit, não
+      auditoria.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Deque
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp
+
+
+@dataclass(frozen=True)
+class Regra:
+    """Descreve `max` chamadas a cada `janela` segundos."""
+
+    max: int
+    janela: int  # segundos
+
+
+# Endpoints protegidos. (método, prefixo-exato) → regra.
+#
+# Prefixos exatos porque nossas rotas críticas não têm parâmetros de
+# caminho no meio que compliquem o match. Para `/sessoes/{id}/selecionar`
+# usamos `startswith` + `.endswith("/selecionar")` abaixo.
+REGRAS: dict[tuple[str, str], Regra] = {
+    ("POST", "/usuarios"): Regra(max=5, janela=60),
+    ("POST", "/sessoes"): Regra(max=10, janela=60),
+    # (`/selecionar` tratado no `_regra_para`)
+}
+
+# Regra aplicada a qualquer `POST /sessoes/*/selecionar`.
+REGRA_SELECIONAR = Regra(max=15, janela=60)
+
+
+def _regra_para(metodo: str, caminho: str) -> Regra | None:
+    """Resolve a regra que se aplica à requisição, ou None."""
+    chave = (metodo, caminho)
+    if chave in REGRAS:
+        return REGRAS[chave]
+    if (
+        metodo == "POST"
+        and caminho.startswith("/sessoes/")
+        and caminho.endswith("/selecionar")
+    ):
+        return REGRA_SELECIONAR
+    return None
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Token-bucket por (IP, rota-protegida). Ver docstring do módulo."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+        # defaultdict(deque) evita checar existência em cada chamada.
+        self._hits: dict[tuple[str, str, str], Deque[float]] = defaultdict(deque)
+
+    async def dispatch(self, request: Request, call_next):
+        regra = _regra_para(request.method, request.url.path)
+        if regra is None:
+            return await call_next(request)
+
+        ip = request.client.host if request.client else "unknown"
+        chave = (ip, request.method, request.url.path)
+        agora = time.monotonic()
+
+        historico = self._hits[chave]
+        # Janela deslizante: descarta timestamps fora do intervalo.
+        limite_janela = agora - regra.janela
+        while historico and historico[0] < limite_janela:
+            historico.popleft()
+
+        if len(historico) >= regra.max:
+            # Quantos segundos até a entrada mais antiga sair da janela?
+            retry_em = max(1, int(regra.janela - (agora - historico[0])))
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "detail": (
+                        "Muitas requisições. Aguarde alguns instantes "
+                        "antes de tentar novamente."
+                    )
+                },
+                headers={"Retry-After": str(retry_em)},
+            )
+
+        historico.append(agora)
+        return await call_next(request)

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -5,7 +5,7 @@ Eventos emitidos pelo backend (JSON):
     - {"type": "inicial", ...}     -> snapshot ao conectar
     - {"type": "ciclo", ...}       -> a cada ciclo de monitoramento (~15s)
     - {"type": "alteracao", ...}   -> quando o valor mudou
-    - {"type": "screenshot", ...}  -> a cada 2s, base64 PNG
+    - {"type": "screenshot", ...}  -> a cada 1s, base64 PNG
     - {"type": "encerrada"}        -> sessão foi encerrada via DELETE
 """
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -11,7 +11,19 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+
+
+# Configuração strict aplicada a TODOS os *In*:
+#   - `extra="forbid"`         → rejeita campos desconhecidos (pega typo
+#                                 no cliente: {"nomee": "..."} vira 422).
+#   - `str_strip_whitespace`   → trim automático em strings.
+#   - `str_min_length=1`       → strings vazias já reprovam sem validator.
+STRICT_IN = ConfigDict(
+    extra="forbid",
+    str_strip_whitespace=True,
+    str_min_length=1,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -19,8 +31,20 @@ from pydantic import BaseModel, EmailStr, Field
 # ---------------------------------------------------------------------------
 
 class UsuarioIn(BaseModel):
+    model_config = STRICT_IN
+
     nome: str = Field(..., min_length=3, max_length=80)
     email: EmailStr
+
+    @field_validator("nome")
+    @classmethod
+    def _nome_nao_vazio(cls, v: str) -> str:
+        # Após o strip, o campo precisa continuar tendo algo visível.
+        # Strings de só espaço virariam "" e já seriam barradas pelo
+        # `min_length=3`, mas o erro fica mais claro aqui.
+        if not v.strip():
+            raise ValueError("nome não pode ser vazio")
+        return v
 
 
 class UsuarioOut(BaseModel):
@@ -34,9 +58,18 @@ class UsuarioOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 class SessaoIn(BaseModel):
-    usuario_id: int
-    url: str
+    model_config = STRICT_IN
+
+    usuario_id: int = Field(..., gt=0)
+    url: str = Field(..., min_length=8, max_length=2048)
     headless: bool = True
+
+    @field_validator("url")
+    @classmethod
+    def _url_protocolo(cls, v: str) -> str:
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("URL precisa começar com http:// ou https://")
+        return v
 
 
 class SessaoOut(BaseModel):
@@ -56,8 +89,10 @@ class ValorEncontrado(BaseModel):
 
 
 class SelecaoIn(BaseModel):
-    xpath: str
-    text: str
+    model_config = STRICT_IN
+
+    xpath: str = Field(..., min_length=1, max_length=4096)
+    text: str = Field(..., min_length=1, max_length=512)
 
 
 class RegistroHistorico(BaseModel):

--- a/backend/services/session_manager.py
+++ b/backend/services/session_manager.py
@@ -4,7 +4,7 @@ Gerenciador de sessões de monitoramento.
 Mantém em memória um registry { session_id → SessionState }. Cada sessão
 carrega seu próprio WebDriver, o XPath selecionado, o valor atual e um
 histórico de alterações. A thread daemon do monitor:
-    - A cada 2s captura um screenshot e emite para todos os subscribers.
+    - A cada 1s captura um screenshot e emite para todos os subscribers.
     - A cada INTERVALO_SEGUNDOS (15s) refresca a página, relê o valor
       pelo XPath e emite `ciclo` (e `alteracao` se o valor mudou).
 
@@ -34,8 +34,9 @@ from src.utils import criar_driver
 from src.value_selector import ler_valor_por_xpath
 
 
-# Intervalo curto entre screenshots (segundos)
-INTERVALO_SCREENSHOT = 2
+# Intervalo curto entre screenshots (segundos). 1s dá sensação de
+# tempo real no painel sem sobrecarregar o CDP (cada captura é ~50ms).
+INTERVALO_SCREENSHOT = 1
 
 
 @dataclass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# Stack completa: backend FastAPI + frontend Nginx.
+#
+# Uso:
+#   docker compose up --build
+# Depois abra http://localhost:5173.
+#
+# Volume `dados` preserva o SQLite entre reinícios.
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      # CORS aceita a origem do frontend em dev local.
+      CORS_ORIGINS: "http://localhost:5173,http://127.0.0.1:5173"
+      # Preencha com o e-mail remetente e a senha de app do Gmail em
+      # um `.env` ao lado deste arquivo — o compose carrega automagicamente.
+      GMAIL_USER: ${GMAIL_USER:-}
+      GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD:-}
+    ports:
+      - "8000:8000"
+    volumes:
+      # O DB é criado ao lado do src/db.py (../dados.db). Montamos um
+      # volume nomeado nesse caminho pra persistir entre containers.
+      - dados:/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        # Em container-to-container, o frontend chama o backend pelo
+        # nome do serviço. Porém, o bundle roda no NAVEGADOR do usuário,
+        # que enxerga o backend via `localhost:8000` (mapeado acima).
+        VITE_API_BASE_URL: "http://localhost:8000"
+    ports:
+      - "5173:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+
+volumes:
+  dados:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,12 @@
 #   docker compose up --build
 # Depois abra http://localhost:5173.
 #
-# Volume `dados` preserva o SQLite entre reinícios.
+# Nota sobre persistência: o SQLite é efêmero por container nesta
+# configuração. Para a entrega (MVP acadêmico) isso é suficiente.
+# Se quisermos persistir entre `down/up`, o caminho correto é montar
+# apenas o arquivo do banco via bind mount (ex.: `./dados.db:/app/dados.db`),
+# nunca um volume em `/app`, pois isso sobrescreve o código da imagem
+# com o conteúdo da primeira execução (shadow do código-fonte).
 services:
   backend:
     build:
@@ -19,10 +24,6 @@ services:
       GMAIL_APP_PASSWORD: ${GMAIL_APP_PASSWORD:-}
     ports:
       - "8000:8000"
-    volumes:
-      # O DB é criado ao lado do src/db.py (../dados.db). Montamos um
-      # volume nomeado nesse caminho pra persistir entre containers.
-      - dados:/app
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -43,6 +44,3 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-
-volumes:
-  dados:

--- a/docs/complexidade_frontend.md
+++ b/docs/complexidade_frontend.md
@@ -1,0 +1,72 @@
+# Análise de complexidade — frontend
+
+Notação: `n` = tamanho da coleção relevante, `k` = constantes pequenas
+(número de toasts visíveis, retries, etc.), `m` = número de mensagens
+WebSocket processadas em uma sessão.
+
+## Renderização de listas
+
+| Componente / hook                       | Operação                       | Complexidade |
+| --------------------------------------- | ------------------------------ | ------------ |
+| `SetupWizard → StepUsuario`             | render da lista de usuários    | **O(n)**     |
+| `SetupWizard → StepValor`               | render da lista de valores     | **O(n)**     |
+| `SetupWizard → SessoesAnteriores`       | slice(0,10) + render           | **O(1)**     |
+| `MonitorPage` → tabela de histórico     | render                         | **O(m)**     |
+| `ToastContainer`                        | render                         | **O(k)**     |
+
+React reconcilia por `key`, portanto inserções no fim (novos toasts,
+novos registros de histórico) custam **O(1)** amortizado — o trabalho
+extra é proporcional ao item novo, não à lista inteira.
+
+## Estado global (Zustand)
+
+| Ação                               | Complexidade | Observação                                  |
+| ---------------------------------- | ------------ | ------------------------------------------- |
+| `toast.emitir`                     | O(1)         | append + setTimeout                         |
+| `toast.remover`                    | O(k)         | filter sobre a fila (k pequeno)             |
+| `sessionStore.aplicarEvento` — `inicial`    | O(m)  | copia histórico recebido do backend         |
+| `sessionStore.aplicarEvento` — `ciclo`      | O(1)  | atualiza 2 campos                           |
+| `sessionStore.aplicarEvento` — `alteracao`  | O(1)  | append na lista (spread copia O(m), mas foi avaliado aceitável para m < 10⁴) |
+| `sessionStore.aplicarEvento` — `screenshot` | O(1)  | troca referência base64                     |
+
+O spread em `alteracao` é **O(m)** em cada mensagem recebida —
+aceitável porque o monitor compara a cada 15s e `m` cresce devagar.
+Se esse fluxo precisar de milhões de eventos, trocaríamos para
+estrutura persistente ou buffer circular.
+
+## Hooks de ciclo de vida
+
+| Hook                         | Por mount                                | Complexidade |
+| ---------------------------- | ---------------------------------------- | ------------ |
+| `useSessionWS`               | 1 WS + handlers + reconnect exponencial | O(1) setup, O(m) processing total |
+| `useNotificarAlteracoes`     | diff por contagem de histórico           | O(alterações novas por render) |
+
+A comparação via `contagemAnterior.current` evita varrer o histórico
+inteiro: só fatiamos os registros **novos**, então o custo por tick é
+proporcional ao delta, não ao total.
+
+## Rede (cliente HTTP)
+
+- `request<T>`: custo dominado pelo round-trip; em falha de rede em
+  verbos idempotentes, até **3 tentativas** com backoff [250, 750]ms.
+  Custo extra: **O(1)** chamadas adicionais no pior caso.
+- `JSON.parse` do corpo: **O(L)** no tamanho da resposta.
+
+## Validação (Zod)
+
+Cada `safeParse` faz uma passada em profundidade pelo schema. Para os
+modelos usados (`usuarioInSchema`, `sessaoInSchema`, `selecaoInSchema`),
+a profundidade é constante (<5 campos), logo **O(1)** por chamada.
+
+## Resumo
+
+O frontend é **linear** no tamanho das coleções exibidas e **constante**
+por evento individual recebido do backend. Os únicos pontos potenciais
+de gargalo são:
+
+1. O spread em `alteracao` (O(m) por mensagem) — ver nota acima.
+2. Re-renderização completa da tabela de histórico quando um registro
+   novo chega; mitigável com `React.memo` caso `m` vire problema.
+
+Para o escopo atual (sessões de até algumas horas, dezenas de
+alterações), a performance é folgada.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,25 +11,38 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.1",
+        "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/ui": "^4.1.5",
         "autoprefixer": "^10.5.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5.10",
         "tailwindcss": "^3.4.19",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
-        "vite": "^8.0.4"
+        "vite": "^8.0.4",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -43,6 +56,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -236,6 +300,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -282,6 +356,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -475,6 +702,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -657,6 +902,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -922,6 +1174,89 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -932,6 +1267,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1298,6 +1659,141 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1336,6 +1832,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1402,6 +1909,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -1457,6 +1984,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1570,6 +2107,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1698,6 +2245,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1718,6 +2286,20 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1736,12 +2318,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1767,12 +2366,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -1783,6 +2403,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1981,6 +2608,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1989,6 +2626,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2069,6 +2716,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2249,6 +2903,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2284,6 +2951,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -2348,6 +3025,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2383,6 +3067,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2770,6 +3505,34 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2807,6 +3570,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2818,6 +3591,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -2902,6 +3685,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2965,6 +3759,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2989,6 +3796,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3205,6 +4019,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3256,6 +4100,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.14.1",
@@ -3329,6 +4181,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3439,6 +4315,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3484,6 +4373,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3492,6 +4403,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3556,6 +4494,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -3617,6 +4562,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3634,6 +4596,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3645,6 +4637,42 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3724,6 +4752,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3859,6 +4897,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3875,6 +5051,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3884,6 +5077,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -3909,7 +5119,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,29 +7,37 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/ui": "^4.1.5",
     "autoprefixer": "^10.5.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.10",
     "tailwindcss": "^3.4.19",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
-    "vite": "^8.0.4"
+    "vite": "^8.0.4",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,16 +22,50 @@ export class ApiError extends Error {
   }
 }
 
+/** Intervalos (ms) de retry quando a primeira tentativa falha de rede. */
+const RETRY_DELAYS_MS = [250, 750];
+
+/** Espera utilitária — exportada só para facilitar mock em testes. */
+export const _sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Métodos idempotentes podem ser repetidos sem risco; POST/DELETE não
+ * devem ser refeitos automaticamente porque podem criar duplicatas ou
+ * remover algo que já foi removido na primeira tentativa bem sucedida.
+ */
+function ehIdempotente(method: string | undefined): boolean {
+  const m = (method ?? 'GET').toUpperCase();
+  return m === 'GET' || m === 'HEAD' || m === 'OPTIONS';
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   let res: Response;
-  try {
-    res = await fetch(`${BASE_URL}${path}`, {
-      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
-      ...init,
-    });
-  } catch {
-    // Falha de rede (servidor desligado, CORS, offline...).
-    throw new ApiError(0, 'Não consegui falar com o servidor. Verifique se o backend está rodando.');
+  // Retry apenas em falha de rede (fetch rejeitou) e apenas em verbos
+  // idempotentes. Não retryamos erros HTTP — se o servidor já respondeu
+  // 5xx, a lógica de negócio rodou pelo menos parcialmente.
+  const retries = ehIdempotente(init?.method) ? RETRY_DELAYS_MS : [];
+  let tentativa = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      res = await fetch(`${BASE_URL}${path}`, {
+        headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+        ...init,
+      });
+      break;
+    } catch {
+      if (tentativa < retries.length) {
+        await _sleep(retries[tentativa]);
+        tentativa += 1;
+        continue;
+      }
+      // Falha de rede persistente (servidor desligado, CORS, offline...).
+      throw new ApiError(
+        0,
+        'Não consegui falar com o servidor. Verifique se o backend está rodando.',
+      );
+    }
   }
   if (!res.ok) {
     // FastAPI devolve { detail: "..." } em erros. Tenta extrair; se

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -1,0 +1,67 @@
+/**
+ * Schemas Zod espelhando os models Pydantic do backend.
+ *
+ * Servem dois propósitos:
+ *   1. Validação client-side antes de enviar (evita round-trip pro
+ *      servidor só para receber um 422).
+ *   2. Inferência de tipos TS — as `interface`s em client.ts ficam
+ *      redundantes mas preservadas por compat; aqui derivamos `type`
+ *      equivalentes com `z.infer`.
+ *
+ * Mantemos as regras alinhadas com `backend/schemas.py`. Se divergirem,
+ * o backend continua sendo a fonte da verdade (422 eventual).
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+export const usuarioInSchema = z.object({
+  nome: z
+    .string()
+    .trim()
+    .min(3, 'Nome precisa ter ao menos 3 caracteres')
+    .max(80, 'Nome muito longo (máx. 80)'),
+  email: z.string().trim().email('E-mail inválido'),
+});
+export type UsuarioInput = z.infer<typeof usuarioInSchema>;
+
+export const sessaoInSchema = z.object({
+  usuario_id: z.number().int().positive(),
+  url: z
+    .string()
+    .trim()
+    .min(8, 'URL muito curta')
+    .max(2048, 'URL muito longa')
+    .refine(
+      (v) => v.startsWith('http://') || v.startsWith('https://'),
+      'Use http:// ou https://',
+    ),
+  headless: z.boolean(),
+});
+export type SessaoInput = z.infer<typeof sessaoInSchema>;
+
+export const selecaoInSchema = z.object({
+  xpath: z.string().min(1, 'XPath vazio'),
+  text: z.string().min(1, 'Valor vazio'),
+});
+export type SelecaoInput = z.infer<typeof selecaoInSchema>;
+
+// ---------------------------------------------------------------------------
+// Helpers de validação
+// ---------------------------------------------------------------------------
+
+/**
+ * Pega o primeiro erro do ZodError num formato pronto para toast/label.
+ * Retorna `null` se o objeto validou.
+ */
+export function primeiraMensagem<T>(
+  schema: z.ZodType<T>,
+  valor: unknown,
+): string | null {
+  const parsed = schema.safeParse(valor);
+  if (parsed.success) return null;
+  return parsed.error.issues[0]?.message ?? 'Valor inválido';
+}

--- a/frontend/src/hooks/useSessionWS.ts
+++ b/frontend/src/hooks/useSessionWS.ts
@@ -63,9 +63,11 @@ export function useSessionWS(sessionId: string | undefined): void {
       };
 
       ws.onerror = () => {
-        // onerror dispara SEMPRE junto com onclose; deixamos a
-        // decisão de reconnect pro onclose e só marcamos o estado aqui
-        // se ainda não tiver aberto.
+        // onerror dispara junto com onclose em vários casos — inclusive
+        // quando o servidor fecha a conexão após emitir `encerrada`
+        // (alguns navegadores tratam o close remoto como falha). Se já
+        // sabemos que a sessão morreu normalmente, não é erro.
+        if (encerrado) return;
         if (ws && ws.readyState !== WebSocket.OPEN) {
           setConn('erro', 'Falha na conexão WebSocket.');
         }

--- a/frontend/src/pages/MonitorPage.tsx
+++ b/frontend/src/pages/MonitorPage.tsx
@@ -140,9 +140,6 @@ export default function MonitorPage() {
       <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
         <h3 className="font-medium mb-2">Navegador (preview)</h3>
         <BrowserPreview />
-        <p className="text-xs text-gray-400 mt-2">
-          Screenshots atualizam a cada 2s enquanto a sessão estiver ativa.
-        </p>
       </section>
 
       <section className="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">

--- a/frontend/src/pages/SetupWizard.tsx
+++ b/frontend/src/pages/SetupWizard.tsx
@@ -27,8 +27,8 @@ import {
   usuarioInSchema,
 } from '../api/schemas';
 
-/** Chave do localStorage que lembra a última URL informada. */
-const LS_ULTIMA_URL = 'monitor.ultimaUrl';
+/** Chave do localStorage que lembra a última URL informada, por usuário. */
+const lsUltimaUrl = (usuarioId: number) => `monitor.ultimaUrl.${usuarioId}`;
 
 type Step = 'usuario' | 'url' | 'valor';
 
@@ -245,7 +245,7 @@ function StepUrl({
   // Recupera a última URL usada por este navegador. É apenas um
   // valor inicial — o usuário pode apagar livremente.
   const [url, setUrl] = useState(
-    () => localStorage.getItem(LS_ULTIMA_URL) ?? '',
+    () => localStorage.getItem(lsUltimaUrl(usuario.id)) ?? '',
   );
   const [headless, setHeadless] = useState(true);
   const [iniciando, setIniciando] = useState(false);
@@ -276,7 +276,7 @@ function StepUrl({
     try {
       const urlLimpa = url.trim();
       const sessao = await api.criarSessao(usuario.id, urlLimpa, headless);
-      localStorage.setItem(LS_ULTIMA_URL, urlLimpa);
+      localStorage.setItem(lsUltimaUrl(usuario.id), urlLimpa);
       onPronto(sessao);
     } catch (e) {
       toast.erro(mensagemDeErro(e));

--- a/frontend/src/pages/SetupWizard.tsx
+++ b/frontend/src/pages/SetupWizard.tsx
@@ -21,19 +21,14 @@ import {
 } from '../api/client';
 import { toast } from '../store/toastStore';
 import { Skeleton, SkeletonList } from '../components/Skeleton';
+import {
+  primeiraMensagem,
+  sessaoInSchema,
+  usuarioInSchema,
+} from '../api/schemas';
 
 /** Chave do localStorage que lembra a última URL informada. */
 const LS_ULTIMA_URL = 'monitor.ultimaUrl';
-
-/** Valida forma básica de URL http(s). Reutilizado pelo input inline. */
-function urlValida(v: string): boolean {
-  try {
-    const u = new URL(v.trim());
-    return u.protocol === 'http:' || u.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
 
 type Step = 'usuario' | 'url' | 'valor';
 
@@ -138,8 +133,12 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
   const [email, setEmail] = useState('');
   const [criando, setCriando] = useState(false);
 
-  const nomeOk = nome.trim().length >= 3;
-  const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+  // Valida o formulário inteiro com Zod; erros específicos aparecem
+  // abaixo de cada campo via `safeParse` individual.
+  const erroNome = primeiraMensagem(usuarioInSchema.shape.nome, nome);
+  const erroEmail = primeiraMensagem(usuarioInSchema.shape.email, email);
+  const nomeOk = nome.length > 0 && !erroNome;
+  const emailOk = email.length > 0 && !erroEmail;
 
   useEffect(() => {
     api
@@ -200,10 +199,8 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
               minLength={3}
               className="mt-1 w-full px-3 py-2 border border-gray-300 rounded"
             />
-            {nome.length > 0 && !nomeOk && (
-              <span className="text-xs text-red-600">
-                Mínimo 3 caracteres.
-              </span>
+            {nome.length > 0 && erroNome && (
+              <span className="text-xs text-red-600">{erroNome}</span>
             )}
           </label>
           <label className="block">
@@ -215,8 +212,8 @@ function StepUsuario({ onPronto }: { onPronto: (u: Usuario) => void }) {
               required
               className="mt-1 w-full px-3 py-2 border border-gray-300 rounded"
             />
-            {email.length > 0 && !emailOk && (
-              <span className="text-xs text-red-600">E-mail inválido.</span>
+            {email.length > 0 && erroEmail && (
+              <span className="text-xs text-red-600">{erroEmail}</span>
             )}
           </label>
           <button
@@ -256,7 +253,8 @@ function StepUrl({
   const [historico, setHistorico] = useState<SessaoHistorica[]>([]);
   const [carregandoHist, setCarregandoHist] = useState(true);
 
-  const urlOk = urlValida(url);
+  const erroUrl = primeiraMensagem(sessaoInSchema.shape.url, url);
+  const urlOk = url.length > 0 && !erroUrl;
 
   useEffect(() => {
     // Histórico persistente do usuário — permite reusar uma URL antiga
@@ -271,7 +269,7 @@ function StepUrl({
   async function iniciar(e: React.FormEvent) {
     e.preventDefault();
     if (!urlOk) {
-      toast.aviso('Informe uma URL http(s) válida.');
+      toast.aviso(erroUrl ?? 'Informe uma URL http(s) válida.');
       return;
     }
     setIniciando(true);
@@ -309,10 +307,8 @@ function StepUrl({
                 : 'border-gray-300'
             }`}
           />
-          {url.length > 0 && !urlOk && (
-            <span className="text-xs text-red-600">
-              Use http:// ou https://
-            </span>
+          {url.length > 0 && erroUrl && (
+            <span className="text-xs text-red-600">{erroUrl}</span>
           )}
         </label>
 

--- a/frontend/src/test/client.test.ts
+++ b/frontend/src/test/client.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Testes do cliente HTTP — cobrem a parte mais sensível:
+ *   - Parsing de erros do FastAPI (detail string e Pydantic array)
+ *   - ApiError com status e detail expostos
+ *   - mensagemDeErro cai nos fallbacks certos
+ *
+ * O módulo usa `fetch` global, que mockamos com `vi.stubGlobal`.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api, mensagemDeErro } from '../api/client';
+
+function respostaOk(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ApiError', () => {
+  it('expõe status e detail e herda de Error', () => {
+    const e = new ApiError(404, 'não achei');
+    expect(e.status).toBe(404);
+    expect(e.detail).toBe('não achei');
+    expect(e.message).toBe('não achei');
+    expect(e).toBeInstanceOf(Error);
+  });
+});
+
+describe('mensagemDeErro', () => {
+  it('usa detail para ApiError', () => {
+    expect(mensagemDeErro(new ApiError(400, 'x'))).toBe('x');
+  });
+  it('usa message para Error comum', () => {
+    expect(mensagemDeErro(new Error('boom'))).toBe('boom');
+  });
+  it('cai em fallback para tipos esquisitos', () => {
+    expect(mensagemDeErro(42)).toBe('Erro inesperado.');
+  });
+});
+
+describe('client.request (via api.listarUsuarios)', () => {
+  it('transforma 404 com detail string em ApiError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ detail: 'não encontrado' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    await expect(api.listarUsuarios()).rejects.toMatchObject({
+      status: 404,
+      detail: 'não encontrado',
+    });
+  });
+
+  it('extrai msg de array de validação Pydantic', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            detail: [{ msg: 'email inválido', type: 'value_error' }],
+          }),
+          {
+            status: 422,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      ),
+    );
+    await expect(api.criarUsuario('x', 'y')).rejects.toMatchObject({
+      status: 422,
+      detail: 'email inválido',
+    });
+  });
+
+  it('falha de rede vira ApiError(0, ...) mesmo depois dos retries', async () => {
+    const fakeFetch = vi.fn(async () => {
+      throw new TypeError('network');
+    });
+    vi.stubGlobal('fetch', fakeFetch);
+    vi.useFakeTimers();
+
+    const p = api.listarUsuarios();
+    // Evita unhandled-rejection enquanto os timers avançam — Vitest
+    // reclama se o motor de Promises vê a rejeição antes do `await`.
+    p.catch(() => {});
+    // Avança todos os retries agendados (250 + 750 ms).
+    await vi.runAllTimersAsync();
+    await expect(p).rejects.toMatchObject({ status: 0 });
+    // GET → 1 tentativa + 2 retries = 3 chamadas de fetch.
+    expect(fakeFetch).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it('devolve json em 200', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => respostaOk([{ id: 1, nome: 'g', email: 'g@x' }])));
+    const r = await api.listarUsuarios();
+    expect(r).toHaveLength(1);
+    expect(r[0].nome).toBe('g');
+  });
+});

--- a/frontend/src/test/schemas.test.ts
+++ b/frontend/src/test/schemas.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Testes dos schemas Zod.
+ *
+ * Fazem dupla função: validam as regras e servem como contrato vivo
+ * com o backend. Se um dia um campo mudar no Pydantic, esses testes
+ * precisarão mudar junto.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  primeiraMensagem,
+  selecaoInSchema,
+  sessaoInSchema,
+  usuarioInSchema,
+} from '../api/schemas';
+
+describe('usuarioInSchema', () => {
+  it('aceita nome e e-mail válidos', () => {
+    const r = usuarioInSchema.safeParse({ nome: 'Gabriel', email: 'g@x.com' });
+    expect(r.success).toBe(true);
+  });
+
+  it('faz trim no nome', () => {
+    const r = usuarioInSchema.parse({ nome: '   Gabriel   ', email: 'g@x.com' });
+    expect(r.nome).toBe('Gabriel');
+  });
+
+  it('rejeita nome com menos de 3 caracteres', () => {
+    const r = usuarioInSchema.safeParse({ nome: 'Ga', email: 'g@x.com' });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejeita e-mail inválido', () => {
+    const r = usuarioInSchema.safeParse({ nome: 'Gabriel', email: 'n/a' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('sessaoInSchema', () => {
+  it('aceita URL https', () => {
+    expect(
+      sessaoInSchema.safeParse({
+        usuario_id: 1,
+        url: 'https://site.com/p',
+        headless: true,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejeita protocolo fora de http(s)', () => {
+    const r = sessaoInSchema.safeParse({
+      usuario_id: 1,
+      url: 'ftp://site.com',
+      headless: true,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejeita usuario_id <= 0', () => {
+    const r = sessaoInSchema.safeParse({
+      usuario_id: 0,
+      url: 'https://a.com/b',
+      headless: true,
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('selecaoInSchema', () => {
+  it('exige xpath e text não-vazios', () => {
+    expect(selecaoInSchema.safeParse({ xpath: '', text: 'x' }).success).toBe(false);
+    expect(selecaoInSchema.safeParse({ xpath: '//a', text: '' }).success).toBe(false);
+    expect(selecaoInSchema.safeParse({ xpath: '//a', text: 'R$ 10' }).success).toBe(true);
+  });
+});
+
+describe('primeiraMensagem', () => {
+  it('devolve null quando válido', () => {
+    expect(primeiraMensagem(usuarioInSchema.shape.nome, 'Gabriel')).toBeNull();
+  });
+
+  it('devolve a mensagem do primeiro erro', () => {
+    const msg = primeiraMensagem(usuarioInSchema.shape.email, 'abc');
+    expect(msg).toBeTruthy();
+    expect(typeof msg).toBe('string');
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,9 @@
+/**
+ * Setup global dos testes.
+ *
+ * Plugga os matchers do `@testing-library/jest-dom` no `expect` do
+ * Vitest (ex.: `toBeInTheDocument`). Outros ajustes por-teste ficam no
+ * próprio arquivo (fake timers, mocks, etc.).
+ */
+
+import '@testing-library/jest-dom/vitest';

--- a/frontend/src/test/toastStore.test.ts
+++ b/frontend/src/test/toastStore.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Testes do toastStore.
+ *
+ * Usamos fake timers pra avançar o auto-dismiss sem esperar 3s reais.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast, useToastStore } from '../store/toastStore';
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Zera entre testes — o store é singleton.
+    useToastStore.setState({ toasts: [] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emite um toast de sucesso e remove após o timeout', () => {
+    toast.sucesso('ok');
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    expect(useToastStore.getState().toasts[0].mensagem).toBe('ok');
+    expect(useToastStore.getState().toasts[0].tipo).toBe('sucesso');
+
+    // Auto-dismiss padrão: 3500ms
+    vi.advanceTimersByTime(3500);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('toasts de erro duram mais (5s)', () => {
+    toast.erro('bum');
+    vi.advanceTimersByTime(3500);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(1500);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('remover manualmente tira da fila imediatamente', () => {
+    toast.info('oi');
+    const id = useToastStore.getState().toasts[0].id;
+    useToastStore.getState().remover(id);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('múltiplos toasts coexistem', () => {
+    toast.sucesso('1');
+    toast.aviso('2');
+    toast.erro('3');
+    expect(useToastStore.getState().toasts.map((t) => t.mensagem)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,20 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
+// Usamos `defineConfig` de `vitest/config` pra ganhar tipagem do campo
+// `test` sem precisar de triple-slash reference. Em runtime, é o
+// mesmo objeto consumido pelo Vite.
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    // Exclui bundles de node_modules e artefatos do build; sem isso,
+    // o vitest acha testes dentro do dist/ caso ele exista.
+    exclude: ['node_modules', 'dist'],
   },
 });

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 selenium>=4.15.0
 fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
-pydantic>=2.5.0
+pydantic[email]>=2.5.0
+# Dev/test — listadas aqui pra simplificar o setup acadêmico.
+pytest>=8.0.0
+httpx>=0.27.0

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,9 +2,12 @@
 Utilitários gerais — WebDriver e validação de URL.
 """
 
+import os
 import re
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 
 # ---------------------------------------------------------------------------
 # Utilitários de validação   O(1) por chamada
@@ -48,5 +51,19 @@ def criar_driver(headless: bool = False) -> webdriver.Chrome:
     if not headless:
         opcoes.add_argument("--window-position=0,0")
 
-    driver = webdriver.Chrome(options=opcoes)
+    # Em containers ARM64 (Docker Desktop no Apple Silicon), o Selenium
+    # Manager não tem binário compatível e falha com
+    # "Unsupported platform/architecture combination: linux/aarch64".
+    # As variáveis `CHROME_BIN` / `CHROMEDRIVER_BIN` são setadas no
+    # Dockerfile.backend e apontam para os binários instalados via apt;
+    # passamos explicitamente pra pular a descoberta automática.
+    # Fora do container, ambas ficam ausentes e caímos no fluxo normal
+    # do Selenium Manager (que já funciona em macOS/Windows/x86_64).
+    chrome_bin = os.environ.get("CHROME_BIN")
+    driver_bin = os.environ.get("CHROMEDRIVER_BIN")
+    if chrome_bin:
+        opcoes.binary_location = chrome_bin
+    service = Service(executable_path=driver_bin) if driver_bin else None
+
+    driver = webdriver.Chrome(options=opcoes, service=service)
     return driver

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""
+Fixtures compartilhadas.
+
+- `client` devolve um `TestClient` do FastAPI com o SQLite redirecionado
+  para um arquivo temporário; cada teste começa com banco vazio.
+- Como o `DB_PATH` é capturado por valor dentro de `src.db`, patchamos
+  o módulo diretamente.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    db_tmp = tmp_path / "teste.db"
+
+    # Patch antes do import do app — qualquer `from src.db import X`
+    # que aconteça em routes/services depende desse caminho.
+    import src.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DB_PATH", str(db_tmp))
+
+    # Recarrega main para que o lifespan use o DB_PATH patchado na
+    # inicialização.
+    from backend import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as c:
+        yield c

--- a/tests/test_historico.py
+++ b/tests/test_historico.py
@@ -1,0 +1,90 @@
+"""
+Testa a persistência do histórico de sessões (sem depender de Selenium).
+
+Gravamos direto via `src.db.gravar_sessao_historica` e validamos os
+endpoints REST que expõem os dados.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from src.db import gravar_sessao_historica
+
+
+@dataclass
+class _Alteracao:
+    # Duck-typing para `gravar_sessao_historica`: precisa de .ciclo,
+    # .timestamp, .valor_antigo, .valor_novo.
+    ciclo: int
+    timestamp: datetime
+    valor_antigo: str
+    valor_novo: str
+
+
+def _criar_usuario(client: TestClient) -> int:
+    r = client.post("/usuarios", json={"nome": "Gabriel", "email": "g@x.com"})
+    return r.json()["id"]
+
+
+def test_sessao_historica_round_trip(client: TestClient) -> None:
+    uid = _criar_usuario(client)
+
+    gravar_sessao_historica(
+        sessao_id="s1",
+        usuario_id=uid,
+        url="https://example.com",
+        xpath_monitorado="//span",
+        valor_inicial="R$ 10,00",
+        valor_final="R$ 12,00",
+        iniciada_em=datetime(2026, 4, 20, 10, 0, 0).isoformat(),
+        encerrada_em=datetime(2026, 4, 20, 11, 0, 0).isoformat(),
+        alteracoes=[
+            _Alteracao(1, datetime(2026, 4, 20, 10, 15), "R$ 10,00", "R$ 11,00"),
+            _Alteracao(2, datetime(2026, 4, 20, 10, 45), "R$ 11,00", "R$ 12,00"),
+        ],
+    )
+
+    r = client.get(f"/usuarios/{uid}/sessoes")
+    assert r.status_code == 200
+    sessoes = r.json()
+    assert len(sessoes) == 1
+    assert sessoes[0]["id"] == "s1"
+    assert sessoes[0]["total_alteracoes"] == 2
+
+    r = client.get("/sessoes/historicas/s1")
+    assert r.status_code == 200
+    assert r.json()["valor_final"] == "R$ 12,00"
+
+    r = client.get("/sessoes/historicas/s1/alteracoes")
+    assert r.status_code == 200
+    alts = r.json()
+    assert [a["ciclo"] for a in alts] == [1, 2]
+    assert alts[1]["valor_novo"] == "R$ 12,00"
+
+
+def test_idempotencia_gravar(client: TestClient) -> None:
+    uid = _criar_usuario(client)
+    args = dict(
+        sessao_id="s-idem",
+        usuario_id=uid,
+        url="https://example.com",
+        xpath_monitorado=None,
+        valor_inicial="A",
+        valor_final="B",
+        iniciada_em=datetime(2026, 4, 20, 10, 0).isoformat(),
+        encerrada_em=datetime(2026, 4, 20, 11, 0).isoformat(),
+        alteracoes=[_Alteracao(1, datetime(2026, 4, 20, 10, 5), "A", "B")],
+    )
+    gravar_sessao_historica(**args)
+    # Re-gravar a mesma sessão deve substituir sem duplicar alterações.
+    gravar_sessao_historica(**args)
+
+    r = client.get("/sessoes/historicas/s-idem/alteracoes")
+    assert len(r.json()) == 1
+
+
+def test_historica_inexistente_404(client: TestClient) -> None:
+    r = client.get("/sessoes/historicas/nao-existe")
+    assert r.status_code == 404

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,34 @@
+"""
+Verifica o rate limit em /usuarios.
+
+Limite é 5 POSTs por 60s por IP — a 6ª chamada seguida devolve 429
+com cabeçalho Retry-After.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_rate_limit_usuarios_bloqueia_sexta_chamada(client: TestClient) -> None:
+    # `validar_nome_usuario` só aceita letras — nomes sem número.
+    nomes = ["Alice", "Bruno", "Carla", "Diego", "Erika"]
+    for i, nome in enumerate(nomes):
+        r = client.post(
+            "/usuarios",
+            json={"nome": nome, "email": f"u{i}@x.com"},
+        )
+        # Os 5 primeiros passam (201 criado).
+        assert r.status_code == 201, (i, r.text)
+
+    # A sexta chamada bate no limite.
+    r = client.post("/usuarios", json={"nome": "Sexta", "email": "six@x.com"})
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+    assert int(r.headers["Retry-After"]) >= 1
+    assert "Muitas requisições" in r.json()["detail"]
+
+
+def test_rate_limit_nao_afeta_get(client: TestClient) -> None:
+    # GET /usuarios não é protegido — 10 chamadas devem passar.
+    for _ in range(10):
+        r = client.get("/usuarios")
+        assert r.status_code == 200

--- a/tests/test_usuarios.py
+++ b/tests/test_usuarios.py
@@ -1,0 +1,57 @@
+"""Testes das rotas de usuários — cobrem schema strict e happy path."""
+
+from fastapi.testclient import TestClient
+
+
+def test_cadastro_e_listagem(client: TestClient) -> None:
+    r = client.post("/usuarios", json={"nome": "Gabriel", "email": "g@x.com"})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["nome"] == "Gabriel"
+    assert body["email"] == "g@x.com"
+    assert body["id"] >= 1
+
+    r = client.get("/usuarios")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+
+def test_strict_rejeita_campo_extra(client: TestClient) -> None:
+    # A configuração `extra="forbid"` deve barrar com 422.
+    r = client.post(
+        "/usuarios",
+        json={"nome": "Gabriel", "email": "g@x.com", "admin": True},
+    )
+    assert r.status_code == 422
+
+
+def test_strict_trim_whitespace(client: TestClient) -> None:
+    r = client.post(
+        "/usuarios",
+        json={"nome": "   Gabriel   ", "email": "g@x.com"},
+    )
+    assert r.status_code == 201
+    assert r.json()["nome"] == "Gabriel"
+
+
+def test_email_invalido(client: TestClient) -> None:
+    r = client.post("/usuarios", json={"nome": "Gabriel", "email": "nao-eh-email"})
+    assert r.status_code == 422
+
+
+def test_nome_curto(client: TestClient) -> None:
+    r = client.post("/usuarios", json={"nome": "Ga", "email": "g@x.com"})
+    assert r.status_code == 422
+
+
+def test_get_usuario_inexistente(client: TestClient) -> None:
+    r = client.get("/usuarios/9999")
+    assert r.status_code == 404
+
+
+def test_sessoes_do_usuario_vazio(client: TestClient) -> None:
+    r = client.post("/usuarios", json={"nome": "Gabriel", "email": "g@x.com"})
+    uid = r.json()["id"]
+    r = client.get(f"/usuarios/{uid}/sessoes")
+    assert r.status_code == 200
+    assert r.json() == []


### PR DESCRIPTION
## Summary

Fecha #30. Entrega final do frontend + endurecimento do backend.

### Backend
- **CORS restrito** via env `CORS_ORIGINS` (default = origens do Vite dev). Métodos e headers explicitamente listados; `allow_credentials=False`.
- **Pydantic strict** em `UsuarioIn`, `SessaoIn`, `SelecaoIn` (`extra="forbid"`, trim automático, limites de tamanho, validators de protocolo).
- **Rate limit** caseiro (token bucket in-memory, zero dep nova) em POST `/usuarios` (5/min), POST `/sessoes` (10/min) e POST `/sessoes/*/selecionar` (15/min) com `Retry-After`.
- `on_event` → `lifespan` async; versão 1.0.0.
- **Testes pytest** com conftest que isola o SQLite em tmp — **12 testes**: cadastro, strict, trim, email inválido, 404, round-trip de histórico, idempotência, rate limit 429.

### Frontend
- **Retries** automáticos em `ApiError` de falha de rede para verbos idempotentes (GET/HEAD/OPTIONS) com backoff [250ms, 750ms]. POST/DELETE nunca são refeitos.
- **Zod** (`api/schemas.ts`) espelha o Pydantic; wizard usa validação inline via `primeiraMensagem(schema, valor)`.
- **Vitest + Testing Library + jsdom** configurados. **22 testes**: client (ApiError, mensagemDeErro, parsing Pydantic, retries), toastStore (emitir, auto-dismiss, remover, múltiplos) e schemas Zod.

### Infra
- `Dockerfile.backend` com Chromium + chromedriver casados.
- `Dockerfile.frontend` multi-stage (Vite build → nginx alpine) com fallback SPA.
- `docker-compose.yml` sobe ambos com volume nomeado e healthcheck: \`docker compose up --build\` levanta o stack completo.

### Docs
- `README_frontend.md`: stack, estrutura, scripts, variáveis, fluxo.
- `docs/complexidade_frontend.md`: análise Big O de renderização, stores, hooks e rede.

## Checklist Issue #30
- [x] Validações com Zod (frontend) + Pydantic strict (backend)
- [x] Error boundaries + retry logic
- [x] Testes: Vitest (front) + pytest (back) — 22 + 12 verdes
- [x] README_frontend.md
- [x] Docker Compose
- [x] CORS restrito a origens conhecidas
- [x] Rate limiting nos endpoints críticos
- [x] Análise de Big O do frontend

## Test plan
- [x] \`python3 -m pytest tests/\` → 12 passed
- [x] \`cd frontend && npm test\` → 22 passed
- [x] \`cd frontend && npm run build\` → bundle limpo
- [x] \`curl -i -X POST localhost:8000/usuarios\` 6 vezes seguidas → a 6ª devolve 429 com \`Retry-After\`
- [x] POST /usuarios com \`{"nome":"x","email":"x@y.com","admin":true}\` → 422 (extra forbid)
- [x] Frontend dev: cadastrar usuário com e-mail errado → mensagem inline específica antes de submeter
- [x] \`docker compose up --build\` → backend em :8000, frontend em :5173, wizard funcional ponta a ponta