### PR TITLE
fix(tz): fixa timezone do backend em America/Sao_Paulo

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -25,7 +25,14 @@ RUN apt-get update \
        libasound2 \
        ca-certificates \
        curl \
+       tzdata \
     && rm -rf /var/lib/apt/lists/*
+
+# Timezone padrão: América/São_Paulo. Pode ser sobrescrito em runtime
+# via `TZ=...` no docker-compose/env quando hospedarmos em outras
+# regiões. Sem isso, VPS em UTC grava timestamps 3h à frente do BR.
+ENV TZ=America/Sao_Paulo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # O Selenium 4 lê o binário do Chrome via PATH quando usamos Service()
 # sem argumentos — já é o default aqui.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     environment:
       # CORS aceita a origem do frontend em dev local.
       CORS_ORIGINS: "http://localhost:5173,http://127.0.0.1:5173"
+      # Timezone do container. Hosts em UTC (VPS típica) geram timestamps
+      # 3h à frente do horário de Brasília — fixamos aqui. Pode ser
+      # sobrescrito via variável de ambiente no host se deployarmos
+      # em outra região (ex.: TZ=Europe/Lisbon).
+      TZ: ${TZ:-America/Sao_Paulo}
       # Preencha com o e-mail remetente e a senha de app do Gmail em
       # um `.env` ao lado deste arquivo — o compose carrega automagicamente.
       GMAIL_USER: ${GMAIL_USER:-}


### PR DESCRIPTION
## Summary
- VPS de produção roda em UTC; sem `TZ` explícito, `datetime.now()` gravava timestamps 3h à frente do horário de Brasília (histórico, eventos WS, resumo por e-mail).
- Instala `tzdata` no `Dockerfile.backend` e fixa `TZ=America/Sao_Paulo` por default.
- Expõe `TZ` como variável de ambiente no `docker-compose.yml` pra sobrescrever em deploy futuro (`TZ=Europe/Lisbon`, etc).

## Test plan
- [x] `docker compose down && docker compose up --build`
- [x] Dentro do container backend: `docker compose exec backend date` → horário de Brasília
- [x] Criar sessão, aguardar um ciclo, verificar que `iniciada_em` / `timestamp` do histórico batem com relógio local
- [x] Deploy na VPS → confirmar que `/usuarios/:id/sessoes` retorna horários corretos