### PR TITLE
fix(notifier): lê GMAIL_* de os.environ antes de cair no .env

### DIFF
--- a/src/notifier.py
+++ b/src/notifier.py
@@ -15,7 +15,21 @@ logger = logging.getLogger(__name__)
 
 
 def _ler_env(chave: str) -> str:
-    """Leitor simples de chave=valor em `.env` (O(n) nas linhas do arquivo)."""
+    """Resolve a chave a partir de `os.environ` e, como fallback, do
+    arquivo `.env` na raiz do repo.
+
+    Em container (Docker/Compose, CI, VPS) as variáveis chegam via
+    `environment:` e NÃO existe `.env` dentro da imagem — por isso o
+    ambiente do processo tem prioridade. O fallback pro arquivo é só
+    pra dev local (rodando `uvicorn` direto sem `docker compose`).
+
+    Complexidade: O(1) quando vem do ambiente, O(n) nas linhas do
+    `.env` no caso de fallback.
+    """
+    valor_env = os.environ.get(chave)
+    if valor_env:
+        return valor_env.strip()
+
     env_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "..", ".env"
     )


### PR DESCRIPTION
## Summary
- Em Docker/VPS, `GMAIL_USER` e `GMAIL_APP_PASSWORD` chegam via `environment:` do compose — ou seja, em `os.environ`. O `.env` não é copiado pra imagem.
- O `_ler_env` em `src/notifier.py` só olhava o arquivo, então em produção sempre retornava vazio → `GMAIL_APP_PASSWORD não configurada; pulando envio`.
- Agora: `os.environ` primeiro, `.env` como fallback pra dev local.

## Test plan
- [x] `docker compose exec backend python -c 'from src.notifier import carregar_senha_app; print(bool(carregar_senha_app()))'` → `True` quando o `.env` do host tem a senha.
- [x] Encerrar uma sessão com histórico → verificar nos logs do backend que o e-mail de resumo sai sem 'pulando envio'.
- [x] Dev local sem docker (rodando uvicorn direto com `.env` na raiz) continua funcionando.